### PR TITLE
Update to remove conflicts associated with py3.8

### DIFF
--- a/envs/default.yaml
+++ b/envs/default.yaml
@@ -4,8 +4,8 @@ channels:
     - bioconda
 dependencies:
     - python=3.8
-    - ipython=7.5.0
-    - numpy=1.16.2
-    - pandas=0.24.2
+    - ipython=7.21.0
+    - numpy=1.20.2
+    - pandas=1.2.3
     - pycountry=18.12.8
-    - jinja2=2.11.2
+    - jinja2=2.11.3


### PR DESCRIPTION
On updating dependencies in #44, defaults.yaml was updated to python 3.8. The other packages in the env needed to also be updated to avoid conflicts. This updates them to match package versions in other envs.