### PR TITLE
Add shell tools (curl/unzip) from conda-forge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,12 @@
 * **ADD** schema that automatically validates configuration files (#45).
 * **ADD** automatic download of hydro basins data (#34).
 * **ADD** minimal configuration to be able to test the entire workflow more quickly (#60).
+* **ADD** installation of `curl` and `unzip` from conda-forge, to increase portability (#59).
 
 * **UPDATE** IRENA hydro generation data from 2018 to 2020 (#40).
 * **UPDATE** Make scaling pumped hydro capacity according to Geth et al. (2015) optional with a boolean config parameter `scale-phs-according-to-geth-et-al` which defaults to False (no scaling) (#49).
-* **UPDATE** JRC hydro database v4 -> v7 (#48). This entails two patches being removed:
+* **UPDATE** JRC hydro database v4 -> v7 (#48). This entails one patch being removed:
     1. Romanian PHS data is no longer manually added from Geth et al. (2015).
-    2. There are no index duplicates to drop in the JRC hydro database.
 * **UPDATE** dependencies (#44):
     * Python 3.7 -> 3.8
     * atlite -> 0.2.1

--- a/Snakefile
+++ b/Snakefile
@@ -51,6 +51,7 @@ rule potentials_zipped:
     message: "Download potential data."
     params: url = config["data-sources"]["potentials"]
     output: protected("data/automatic/raw-potentials.zip")
+    conda: "envs/shell.yaml"
     shell: "curl -sLo {output} '{params.url}'"
 
 
@@ -64,6 +65,7 @@ rule potentials:
         demand = "build/data/{resolution}/demand.csv",
         population = "build/data/{resolution}/population.csv",
         land_cover = "build/data/{resolution}/land-cover.csv"
+    conda: "envs/shell.yaml"
     shell: "unzip -o {input} -d build/data"
 
 
@@ -171,6 +173,7 @@ rule download_capacity_factors_wind_and_solar:
     message: "Download data/automatic/capacityfactors/{wildcards.filename}."
     params: url = lambda wildcards: config["data-sources"]["capacity-factors"].format(filename=wildcards.filename)
     output: protected("data/automatic/capacityfactors/{filename}")
+    conda: "envs/shell.yaml"
     shell: "curl -sLo {output} '{params.url}'"
 
 
@@ -231,6 +234,7 @@ rule raw_load:
     message: "Download raw load."
     params: url = config["data-sources"]["load"]
     output: protected("data/automatic/raw-load-data.csv")
+    conda: "envs/shell.yaml"
     shell: "curl -sLo {output} '{params.url}'"
 
 

--- a/envs/shell.yaml
+++ b/envs/shell.yaml
@@ -1,0 +1,6 @@
+name: shell
+channels:
+    - conda-forge
+dependencies:
+    - curl=7.76.0
+    - unzip=6.0

--- a/rules/hydro.smk
+++ b/rules/hydro.smk
@@ -28,6 +28,7 @@ rule download_basins_database:
     params: url = config["data-sources"]["hydro-basins"]
     output:
         protected("data/automatic/raw-hydro-basins.zip")
+    conda: "../envs/shell.yaml"
     shell:
         "curl -sLo {output} '{params.url}'"
 
@@ -37,6 +38,7 @@ rule download_stations_database:
     params: url = config["data-sources"]["hydro-stations"]
     output:
         protected("data/automatic/raw-hydro-stations.zip")
+    conda: "../envs/shell.yaml"
     shell:
         "curl -sLo {output} '{params.url}'"
 
@@ -45,6 +47,7 @@ rule basins_database:
     message: "Unzip basins database."
     input: rules.download_basins_database.output
     output: "build/data/basins/hybas_eu_lev07_v1c.shp"
+    conda: "../envs/shell.yaml"
     shell: "unzip {input} -d ./build/data/basins/"
 
 
@@ -53,6 +56,7 @@ rule stations_database:
     input: rules.download_stations_database.output
     output: "build/data/jrc-hydro-power-plant-database.csv"
     shadow: "full"
+    conda: "../envs/shell.yaml"
     shell:
         """
         unzip -j {input} "**/jrc-hydro-power-plant-database.csv" -d build/data/

--- a/rules/shapes.smk
+++ b/rules/shapes.smk
@@ -22,6 +22,7 @@ rule raw_gadm_administrative_borders_zipped:
     message: "Download administrative borders for {wildcards.country_code} as zip."
     params: url = lambda wildcards: config["data-sources"]["gadm"].format(country_code=wildcards.country_code)
     output: protected("data/automatic/raw-gadm/{country_code}.zip")
+    conda: "../envs/shell.yaml"
     shell: "curl -sLo {output} '{params.url}'"
 
 
@@ -29,6 +30,7 @@ rule raw_gadm_administrative_borders:
     message: "Unzip administrative borders of {wildcards.country_code} as zip."
     input: "data/automatic/raw-gadm/{country_code}.zip"
     output: temp("data/automatic/raw-gadm/gadm36_{country_code}.gpkg")
+    conda: "../envs/shell.yaml"
     shell: "unzip -o {input} -d data/automatic/raw-gadm"
 
 
@@ -57,6 +59,7 @@ rule raw_nuts_units_zipped:
     message: "Download units as zip."
     params: url = config["data-sources"]["nuts"]
     output: protected("data/automatic/raw-nuts-units.zip")
+    conda: "../envs/shell.yaml"
     shell: "curl -sLo {output} '{params.url}'"
 
 


### PR DESCRIPTION
This increases portability of the workflow. Fixes #59.

I've tested this locally. The minimal workflow runs. The workflow uses libs from conda-forge, rather than my local tools.