### PR TITLE
Make schema checker strict to typos

### DIFF
--- a/tests/validate_schema.py
+++ b/tests/validate_schema.py
@@ -21,4 +21,7 @@ if args.config:
         config = yaml.safe_load(f)
     jsonschema.validate(config, schema)
 else:
+    # We set the metaschema 'additionalProperties' to False to create a 'strict' schema checker,
+    # which will fail on typos
+    jsonschema.Draft7Validator.META_SCHEMA['additionalProperties'] = False
     jsonschema.Draft7Validator.check_schema(schema)


### PR DESCRIPTION
The JSON schema checker ignores typos, which seems to me to a big oversight (one which caught us out in #75). This change is a bit of a hack as I have not found an approach to make the metaschema strict with an explicit argument. Nonetheless, it's quite a transparent hack: it just ensures no additional 'properties' are allowed in the schema other than those defined in the schema draft. On testing it locally, it seems to be effective.