### PR TITLE
Adding Danish Energy Agency cost data and removing default costs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 1.1 (unpublished)
-
+* **ADD** Aggregate cost data in `tech-costs.yaml` and add overrides to that file (#18, #129)
 * **ADD** Add basic documentation to ReadTheDocs (#114).
 * **ADD** ability to move working directory (#45).
 * **ADD** schema that automatically validates configuration files (#45).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 1.1 (unpublished)
-* **ADD** Aggregate cost data in `tech-costs.yaml` and add overrides to that file (#18, #129)
+* **ADD** Danish Energy Agency and Schroeder et al (2013) cost data as well as no hydro fixed costs as optional overrides (#18, #129).
 * **ADD** Add basic documentation to ReadTheDocs (#114).
 * **ADD** ability to move working directory (#45).
 * **ADD** schema that automatically validates configuration files (#45).

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ After a successful full build (see "Build the model"), the following files will 
 ├── interest-rate.yaml                     <- Interest rate of all capacities.
 ├── link-techs.yaml                        <- Definition of link technologies.
 ├── README.md                              <- Documentation.
-├── cost-overrides .yaml                   <- Cost data from different sources.
+├── tech-costs.yaml                        <- Definition of cost data.
 ├── renewable-techs.yaml                   <- Definition of supply technologies.
 └── storage-techs.yaml                     <- Definition of storage technologies.
 ```

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ To remove cluster results on your local machine, run `snakemake --use-conda clea
 The build step creates all individual components of `euro-calliope`, like technologies and time series. These can be combined to eventually build a final model to run simulations with. For an example of such a model, see `./build/model/{resolution}/example-model.yaml`. It is a complete Calliope model and can be used like any other, for example like this:
 
 ```Bash
-$ calliope run ./build/model/national/example-model.yaml --scenario=etri-renewable-cost,etri-hydro-cost
+$ calliope run ./build/model/national/example-model.yaml
 ```
 
 For more information on how to use and modify Calliope models, see [Calliope's documentation](https://calliope.readthedocs.io).

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ After a successful full build (see "Build the model"), the following files will 
 ├── interest-rate.yaml                     <- Interest rate of all capacities.
 ├── link-techs.yaml                        <- Definition of link technologies.
 ├── README.md                              <- Documentation.
+├── cost-overrides .yaml                   <- Cost data from different sources.
 ├── renewable-techs.yaml                   <- Definition of supply technologies.
 └── storage-techs.yaml                     <- Definition of storage technologies.
 ```

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ To remove cluster results on your local machine, run `snakemake --use-conda clea
 The build step creates all individual components of `euro-calliope`, like technologies and time series. These can be combined to eventually build a final model to run simulations with. For an example of such a model, see `./build/model/{resolution}/example-model.yaml`. It is a complete Calliope model and can be used like any other, for example like this:
 
 ```Bash
-$ calliope run ./build/model/national/example-model.yaml
+$ calliope run ./build/model/national/example-model.yaml --scenario=etri-renewable-cost,etri-hydro-cost
 ```
 
 For more information on how to use and modify Calliope models, see [Calliope's documentation](https://calliope.readthedocs.io).

--- a/Snakefile
+++ b/Snakefile
@@ -93,7 +93,7 @@ rule parameterise_template:
         biofuel_efficiency = config["parameters"]["biofuel-efficiency"]
     output: "build/model/{template}"
     wildcard_constraints:
-        template = "((link-techs.yaml)|(storage-techs.yaml)|(demand-techs.yaml)|(renewable-techs.yaml)|(README.md)|(environment.yaml)|(interest-rate.yaml)|(cost-overrides.yaml))"
+        template = "((link-techs.yaml)|(storage-techs.yaml)|(demand-techs.yaml)|(renewable-techs.yaml)|(README.md)|(environment.yaml)|(interest-rate.yaml)|(tech-costs.yaml))"
     conda: "envs/default.yaml"
     script: "scripts/parameterise_templates.py"
 
@@ -302,7 +302,7 @@ rule model:
     input:
         "build/model/interest-rate.yaml",
         "build/model/link-techs.yaml",
-        "build/model/cost-overrides.yaml",
+        "build/model/tech-costs.yaml",
         "build/model/renewable-techs.yaml",
         "build/model/storage-techs.yaml",
         "build/model/demand-techs.yaml",

--- a/Snakefile
+++ b/Snakefile
@@ -93,7 +93,7 @@ rule parameterise_template:
         biofuel_efficiency = config["parameters"]["biofuel-efficiency"]
     output: "build/model/{template}"
     wildcard_constraints:
-        template = "((link-techs.yaml)|(storage-techs.yaml)|(demand-techs.yaml)|(renewable-techs.yaml)|(README.md)|(environment.yaml)|(interest-rate.yaml))"
+        template = "((link-techs.yaml)|(storage-techs.yaml)|(demand-techs.yaml)|(renewable-techs.yaml)|(README.md)|(environment.yaml)|(interest-rate.yaml)|(cost-overrides.yaml))"
     conda: "envs/default.yaml"
     script: "scripts/parameterise_templates.py"
 

--- a/Snakefile
+++ b/Snakefile
@@ -302,6 +302,7 @@ rule model:
     input:
         "build/model/interest-rate.yaml",
         "build/model/link-techs.yaml",
+        "build/model/cost-overrides.yaml",
         "build/model/renewable-techs.yaml",
         "build/model/storage-techs.yaml",
         "build/model/demand-techs.yaml",

--- a/docs/source/sources.md
+++ b/docs/source/sources.md
@@ -45,7 +45,3 @@ Schröder, A., Kunz, F., Meiss, J., Mendelevitch, R., &#38; Von Hirschhausen, C.
 > [@DEA:2020]
 
 Danish Energy Agency. (2020). <i>Technology Data for Generation of Electricity and District Heating.</i> https://ens.dk/en/our-services/projections-and-models/technology-data/technology-data-generation-electricity-and 
-
-> [@DEA:2017]
-
-Danish Energy Agency. (2017). <i>Technology Data for Renewable Fuels.</i> https://ens.dk/en/our-services/projections-and-models/technology-data/technology-data-renewable-fuels  

--- a/docs/source/sources.md
+++ b/docs/source/sources.md
@@ -38,6 +38,14 @@ European Environment Agency. (2009). <i>Europe’s onshore and offshore wind ene
 
 Ruiz Castello, P., Sgobbi, A., Nijs, W., Thiel, C., Dalla Longa, F., Kober, T., Elbersen, B., &#38; Hengeveld, G. (2015). <i>The JRC-EU-TIMES model. Bioenergy potentials for EU and neighbouring countries.</i> https://ec.europa.eu/jrc/en/publication/eur-scientific-and-technical-research-reports/jrc-eu-times-model-bioenergy-potentials-eu-and-neighbouring-countries
 
+> [@schroeder:2013]
+
+Schröder, A., Kunz, F., Meiss, J., Mendelevitch, R., &#38; Von Hirschhausen, C. (2013). <i>Current and prospective costs of electricity generation until 2050.</i> https://www.econstor.eu/bitstream/10419/80348/1/757528015.pdf 
+
 > [@DEA:2020]
 
 Danish Energy Agency. (2020). <i>Technology Data for Generation of Electricity and District Heating.</i> https://ens.dk/en/our-services/projections-and-models/technology-data/technology-data-generation-electricity-and 
+
+> [@DEA:2017]
+
+Danish Energy Agency. (2017). <i>Technology Data for Renewable Fuels.</i> https://ens.dk/en/our-services/projections-and-models/technology-data/technology-data-renewable-fuels  

--- a/docs/source/sources.md
+++ b/docs/source/sources.md
@@ -40,4 +40,4 @@ Ruiz Castello, P., Sgobbi, A., Nijs, W., Thiel, C., Dalla Longa, F., Kober, T., 
 
 > [@DEA:2020]
 
-Danish Energy Agency (2020). <i>Technology Data for Generation of Electricity and District Heating.<.i> https://ens.dk/en/our-services/projections-and-models/technology-data/technology-data-generation-electricity-and 
+Danish Energy Agency. (2020). <i>Technology Data for Generation of Electricity and District Heating.</i> https://ens.dk/en/our-services/projections-and-models/technology-data/technology-data-generation-electricity-and 

--- a/docs/source/sources.md
+++ b/docs/source/sources.md
@@ -37,3 +37,7 @@ European Environment Agency. (2009). <i>Europe’s onshore and offshore wind ene
 > [@Ruiz Catello et al:2015]
 
 Ruiz Castello, P., Sgobbi, A., Nijs, W., Thiel, C., Dalla Longa, F., Kober, T., Elbersen, B., &#38; Hengeveld, G. (2015). <i>The JRC-EU-TIMES model. Bioenergy potentials for EU and neighbouring countries.</i> https://ec.europa.eu/jrc/en/publication/eur-scientific-and-technical-research-reports/jrc-eu-times-model-bioenergy-potentials-eu-and-neighbouring-countries
+
+> [@DEA:2020]
+
+Danish Energy Agency (2020). <i>Technology Data for Generation of Electricity and District Heating.<.i> https://ens.dk/en/our-services/projections-and-models/technology-data/technology-data-generation-electricity-and 

--- a/templates/README.md
+++ b/templates/README.md
@@ -24,30 +24,24 @@ conda activate euro-calliope
 There are three models in this directory -- one for each of the three spatial resolutions continental, national, and regional. You can run all three models out-of-the-box, but you may want to modify the model. By default, the model runs for the first day of January only. To run the example model on the continental resolution type:
 
 ```Bash
-$ calliope run ./continental/example-model.yaml --scenario=etri-renewable-cost,etri-hydro-cost
+$ calliope run ./continental/example-model.yaml
 ```
 
 For more information on how to use and modify Calliope models, see [Calliope's documentation](https://calliope.readthedocs.io).
 
 ## Manipulating the model using overrides
 
-Calliope [overrides](https://calliope.readthedocs.io/en/stable/user/building.html#scenarios-and-overrides) allow to easily manipulate models. An override named `freeze-hydro-capacities` can be used for example in this way:
+Calliope [overrides](https://calliope.readthedocs.io/en/stable/user/building.html#scenarios-and-overrides) allow to easily manipulate models. An override named `dea-renewable-cost` can be used for example in this way:
 
 ```bash
-calliope run build/model/continental/example-model.yaml --scenario=etri-renewable-cost,etri-hydro-cost
+calliope run build/model/continental/example-model.yaml --scenario=dea-renewable-cost
 ```
 
 You can define your own overrides to manipulate any model component. The following overrides are built into euro-calliope:
 
 > cost assumptions
 
-By default, no cost or lifetime is specified for renewable technologies in euro-calliope. 
-
-Either `etri-renewable-cost` or  `dea-renewable-cost` have to be chosen as an override to specify the cost for solar PV, wind power and biomass using data from either the JRC or from the Danish Energy Agency.
-
-To assign costs to hydro reservoirs and run-of-river hydro, one of `no-hydro-cost`, `etri-hydro-cost` or `schroeder-hydro-cost` has to be chosen. The first of those allows to only consider variable and O&M costs since hydropower capacities by default are constrained to current capacities. 
-
-Unmet demand can also be assigned a cost using the override `load-shedding`.
+By default, euro-calliope uses cost and lifetime projections from the JRC Energy Technology Reference Indicator 2014. The `dea-renewable-cost` override allows to use the projections from the Danish Energy Agency instead for solar PV, wind power and biomass and `schroeder-hydro-cost` provides another source for the hydropower assumptions. Using the override `no-hydro-fixed-cost` allows to only consider variable and O&M costs for hydropower since the capacities are constrained to current levels by default. 
 
 > directional-rooftop-pv
 
@@ -58,10 +52,6 @@ When using the `directional-rooftop-pv` override, there are three instead of jus
 > freeze-hydro-capacities
 
 By default, euro-calliope allows capacities of run-of-river hydro, reservoir hydro, and pumped storage hydro capacities up to today's levels. Alternatively, it's possible to freeze these capacities to today's levels using the `freeze-hydro-capacities` override.
-
-> stylised storage
-
-`stylised-storage` allows to constrain the energy-to-power ratios of battery and hydrogen.
 
 ## Model components
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -68,6 +68,7 @@ The models contain the following files. All files in the root directory are inde
 ├── interest-rate.yaml                     <- Interest rates of all capacities.
 ├── link-techs.yaml                        <- Definition of link technologies.
 ├── README.md                              <- The file you are currently looking at.
+├── cost-overrides.yaml                    <- Cost data from different sources.
 ├── renewable-techs.yaml                   <- Definition of supply technologies.
 └── storage-techs.yaml                     <- Definition of storage technologies.
 ```

--- a/templates/README.md
+++ b/templates/README.md
@@ -41,7 +41,7 @@ You can define your own overrides to manipulate any model component. The followi
 
 > cost assumptions
 
-By default, euro-calliope uses cost and lifetime projections from the JRC Energy Technology Reference Indicator 2014. The `dea-renewable-cost` override allows to use the projections from the Danish Energy Agency instead for solar PV, wind power and biomass and `schroeder-hydro-cost` provides another source for the hydropower assumptions. Using the override `no-hydro-fixed-cost` allows to only consider variable and O&M costs for hydropower since the capacities are constrained to current levels by default. 
+By default, euro-calliope uses cost and lifetime projections from the JRC Energy Technology Reference Indicator 2014. The `dea-renewable-cost` override allows to use the projections from the Danish Energy Agency instead for solar PV, wind power and biomass and `schroeder-hydro-cost` provides another source for the hydropower assumptions. Using the override `no-hydro-fixed-cost` allows to only consider variable and O&M costs for hydropower. This may make sense especially in combination with the `freeze-hydro-capacities` override (see below).
 
 > directional-rooftop-pv
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -41,7 +41,7 @@ You can define your own overrides to manipulate any model component. The followi
 
 > cost assumptions
 
-By default, euro-calliope uses cost and lifetime projections from the JRC Energy Technology Reference Indicator 2014. The `dea-renewable-cost` override allows to use the projections from the Danish Energy Agency instead for solar PV, wind power and biomass and `schroeder-hydro-cost` provides another source for the hydropower assumptions. Using the override `no-hydro-fixed-cost` allows to only consider variable and O&M costs for hydropower. This may make sense especially in combination with the `freeze-hydro-capacities` override (see below).
+By default, euro-calliope uses cost and lifetime projections from the JRC Energy Technology Reference Indicator 2014. The `dea-renewable-cost` override allows to use the projections from the Danish Energy Agency instead for solar PV and wind power and `schroeder-hydro-cost` provides another source for the hydropower assumptions. Using the override `no-hydro-fixed-cost` allows to only consider variable and O&M costs for hydropower. This may make sense especially in combination with the `freeze-hydro-capacities` override (see below).
 
 > directional-rooftop-pv
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -24,7 +24,7 @@ conda activate euro-calliope
 There are three models in this directory -- one for each of the three spatial resolutions continental, national, and regional. You can run all three models out-of-the-box, but you may want to modify the model. By default, the model runs for the first day of January only. To run the example model on the continental resolution type:
 
 ```Bash
-$ calliope run ./continental/example-model.yaml
+$ calliope run ./continental/example-model.yaml --scenario=etri-renewable-cost,etri-hydro-cost
 ```
 
 For more information on how to use and modify Calliope models, see [Calliope's documentation](https://calliope.readthedocs.io).

--- a/templates/README.md
+++ b/templates/README.md
@@ -34,10 +34,20 @@ For more information on how to use and modify Calliope models, see [Calliope's d
 Calliope [overrides](https://calliope.readthedocs.io/en/stable/user/building.html#scenarios-and-overrides) allow to easily manipulate models. An override named `freeze-hydro-capacities` can be used for example in this way:
 
 ```bash
-calliope run build/model/continental/example-model.yaml --scenario=freeze-hydro-capacities
+calliope run build/model/continental/example-model.yaml --scenario=etri-renewable-cost,etri-hydro-cost
 ```
 
 You can define your own overrides to manipulate any model component. The following overrides are built into euro-calliope:
+
+> cost assumptions
+
+By default, no cost or lifetime is specified for renewable technologies in euro-calliope. 
+
+Either `etri-renewable-cost` or  `dea-renewable-cost` have to be chosen as an override to specify the cost for solar PV, wind power and biomass using data from either the JRC or from the Danish Energy Agency.
+
+To assign costs to hydro reservoirs and run-of-river hydro, one of `no-hydro-cost`, `etri-hydro-cost` or `schroeder-hydro-cost` has to be chosen. The first of those allows to only consider variable and O&M costs since hydropower capacities by default are constrained to current capacities. 
+
+Unmet demand can also be assigned a cost using the override `load-shedding`.
 
 > directional-rooftop-pv
 
@@ -48,6 +58,10 @@ When using the `directional-rooftop-pv` override, there are three instead of jus
 > freeze-hydro-capacities
 
 By default, euro-calliope allows capacities of run-of-river hydro, reservoir hydro, and pumped storage hydro capacities up to today's levels. Alternatively, it's possible to freeze these capacities to today's levels using the `freeze-hydro-capacities` override.
+
+> stylised storage
+
+`stylised-storage` allows to constrain the energy-to-power ratios of battery and hydrogen.
 
 ## Model components
 
@@ -68,7 +82,7 @@ The models contain the following files. All files in the root directory are inde
 ├── interest-rate.yaml                     <- Interest rates of all capacities.
 ├── link-techs.yaml                        <- Definition of link technologies.
 ├── README.md                              <- The file you are currently looking at.
-├── cost-overrides.yaml                    <- Cost data from different sources.
+├── tech-costs.yaml                        <- Definition of cost data.
 ├── renewable-techs.yaml                   <- Definition of supply technologies.
 └── storage-techs.yaml                     <- Definition of storage technologies.
 ```

--- a/templates/cost-overrides.yaml
+++ b/templates/cost-overrides.yaml
@@ -1,0 +1,100 @@
+overrides:
+    dea-renewable-cost: # from [@DEA:2020]
+        tech_groups.pv_on_roof: #  Sheet 22 - Photovoltaics Small (2016)
+            constraints.lifetime: 40 
+            costs.monetary:
+                energy_cap: {{ 560000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}
+                om_annual: {{ (8700  - 1 * 8760 * capacity_factors.pv) * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}
+                om_prod: {{1 * scaling_factors.specific_costs}} # stolen from om_annual for technical reasons
+        techs.open_field_pv: # Sheet 22 - Photovoltaics Large (2016)
+            constraints.lifetime: 40
+            costs.monetary:
+                energy_cap: {{ 241000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}
+                om_annual: {{ (5000 - 1 * 8760 * capacity_factors.pv) * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW/year") }}
+                om_prod: {{1 * scaling_factors.specific_costs}} # stolen from om_annual for technical reasons
+        tech_groups.wind_onshore: # Sheet 20 Onshore Turbines (2019)
+            constraints.lifetime: 30
+            costs.monetary:
+                energy_cap: {{ 963000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}
+                om_annual: {{ (11340 - 1 * 8760 * capacity_factors.onshore) * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW/year") }}
+                om_prod: {{1 * scaling_factors.specific_costs}} #stolen from om_annual for technical reasons
+        techs.wind_offshore: # Sheet 21 Offshore Turbines (2019)
+            constraints.lifetime: 30
+            costs.monetary:
+                energy_cap: {{ 1777000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}
+                om_annual: {{ (32448 - 1 * 8760 * capacity_factors.offshore) * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW/year") }}
+                om_prod: {{1 * scaling_factors.specific_costs}} # stolen from om_annual for technical reasons
+        techs.biofuel:  # Sheet 09a Wood Chips, Medium (CHP with 80MW feed) (2020)
+            constraints.lifetime: 25
+            costs.monetary:
+                energy_cap: {{ 935800 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}
+                om_annual: {{ 37800 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW/year") }}
+                om_prod: 0 # 1.3 (EUR2015/MWh) added to om_con because value is very small and causing poor numerical range
+                om_con: {{ (biofuel_fuel_cost / biofuel_efficiency + 1.3) * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}
+    etri-renewable-cost: # from [@JRC:2014]
+        tech_groups.pv_on_roof:  # Table 9
+            constraints.lifetime: 25
+            costs.monetary:
+                energy_cap: {{ 880000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
+                om_annual: {{ (880000 * 0.02 - 1 * 8760 * capacity_factors.pv) * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 2% of CAPEX
+                om_prod: {{1 * scaling_factors.specific_costs}} # stolen from om_annual for technical reasons
+        techs.open_field_pv: #Table 7
+            constraints.lifetime: 25
+            costs.monetary:
+                energy_cap: {{ 520000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
+                om_annual: {{ (520000 * 0.017 - 1 * 8760 * capacity_factors.pv) * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 1.7% of CAPEX
+                om_prod: {{1 * scaling_factors.specific_costs}} # stolen from om_annual for technical reasons
+        tech_groups.wind_onshore: #Table 4
+            constraints.lifetime: 25
+            costs.monetary:
+                energy_cap: {{ 1100000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
+                om_annual: {{ (1100000 * 0.017 - 1 * 8760 * capacity_factors.onshore) * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 1.7% of CAPEX
+                om_prod: {{1 * scaling_factors.specific_costs}} # stolen from om_annual for technical reasons
+        techs.wind_offshore: #Table 5
+            constraints.lifetime: 30
+            costs.monetary:
+                energy_cap: {{ 2280000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
+                om_annual: {{ (2280000 * 0.023 - 1 * 8760 * capacity_factors.offshore) * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 2.3% of CAPEX
+                om_prod: {{1 * scaling_factors.specific_costs}} # stolen from om_annual for technical reasons
+        techs.biofuel: # Table 48 Anaerobic digestion
+            constraints.lifetime: 20
+            costs.monetary:
+                energy_cap: {{2300000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
+                om_annual: {{2300000 * 0.041 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 4.1% of CAPEX
+                om_con: {{ (biofuel_fuel_cost / biofuel_efficiency + 3.1) * scaling_factors.specific_costs }} # unit("EUR2013/MWh")
+                om_prod: 0 # 3.1 (EUR2013/MWh) added to om_con because value is very small and causing poor numerical range
+    etri-hydro-cost: # from [@JRC:2014]
+        techs.hydro_run_of_river.costs.monetary: # Table 14
+            energy_cap: {{5620000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
+            om_annual: {{5620000 * 0.03 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 3% of CAPEX
+            om_prod: {{5 * scaling_factors.specific_costs}} # unit("EUR2013/MWh)") 
+        techs.hydro_reservoir.costs.monetary: # Table 12
+            energy_cap: {{3370000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
+            om_annual: {{3370000 * 0.03 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 3% of CAPEX
+            om_prod: {{5 * scaling_factors.specific_costs}} #  unit("EUR2013/MWh)") 
+    schroeder-hydro-cost: # from [@schroeder:2013]
+        techs.hydro_run_of_river.costs.monetary:
+            energy_cap: {{3000000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2010/MW") }} Table 33
+            om_annual: {{60000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2010/MW") }} Table 34
+            om_prod: 0 # Table 34
+        techs.hydro_reservoir.costs.monetary:
+            energy_cap: {{ 2000000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2010/MW") }} Table 33
+            om_annual: {{ 20000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2010/MW") }} Table 34
+            om_prod: 0 # Table 34
+    schmidt-storage-cost: # from [@schmidt:2019] Table S4
+        techs.battery.costs.monetary:
+            storage_cap: {{723130 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}
+            energy_cap: {{611324 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}
+            om_annual: {{9016 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}
+            om_prod: {{2.7 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}
+        techs.pumped_hydro.costs.monetary:
+            storage_cap: {{72133 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}
+            energy_cap: {{1017973 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}
+            om_annual: {{7213 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}
+            om_prod: {{1 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}
+        techs.hydrogen.costs.monetary:
+            storage_cap: {{27951 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}
+            energy_cap: {{4884287 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}
+            om_annual: {{41476 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}
+            om_prod: 0 
+

--- a/templates/example-model.yaml
+++ b/templates/example-model.yaml
@@ -4,7 +4,7 @@ import:
     - '../storage-techs.yaml'
     - '../link-techs.yaml'
     - '../demand-techs.yaml'
-    - '../cost-overrides.yaml'
+    - '../tech-costs.yaml'
     - 'locations.yaml'
     - 'directional-rooftop.yaml'
     - 'link-all-neighbours.yaml'

--- a/templates/example-model.yaml
+++ b/templates/example-model.yaml
@@ -4,6 +4,7 @@ import:
     - '../storage-techs.yaml'
     - '../link-techs.yaml'
     - '../demand-techs.yaml'
+    - '../cost-overrides.yaml'
     - 'locations.yaml'
     - 'directional-rooftop.yaml'
     - 'link-all-neighbours.yaml'

--- a/templates/link-techs.yaml
+++ b/templates/link-techs.yaml
@@ -7,9 +7,6 @@ techs:
         constraints:
             energy_cap_max: inf
             energy_eff: 1.0
-        costs:
-            monetary:
-                om_prod: 0
     ac_transmission:
         essentials:
             name: "High voltage AC transmission line"
@@ -17,8 +14,3 @@ techs:
             carrier: electricity
         constraints:
             energy_eff_per_distance: 0.99999995 # (1/m)
-            lifetime: 60 # [@JRC:2014]
-        costs:
-            monetary:
-                energy_cap_per_distance: {{ 0.9 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW/m") }} from [@JRC:2014], Table 39
-                om_annual_investment_fraction: 0.015 # from [@JRC:2014], Table 39

--- a/templates/renewable-techs.yaml
+++ b/templates/renewable-techs.yaml
@@ -63,6 +63,13 @@ techs:
         constraints:
             resource: file=capacityfactors-wind-offshore.csv
             resource_unit: energy_per_cap
+    load_shedding:
+        essentials:
+            name: Load shedding as last resort
+            parent: supply
+            carrier: electricity
+        constraints:
+            energy_cap_max: inf
     hydro_run_of_river:
         essentials:
             name: Run of river hydro electricity

--- a/templates/renewable-techs.yaml
+++ b/templates/renewable-techs.yaml
@@ -6,15 +6,9 @@ tech_groups:
             parent: supply
         constraints:
             energy_cap_max: inf # see https://github.com/calliope-project/calliope/issues/161
-            lifetime: 25 # [@JRC:2014] Table 7
     pv_on_roof:
         essentials:
             parent: pv
-        costs:
-            monetary:
-                energy_cap: {{ 880000 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} from [@JRC:2014] Table 9
-                om_annual: {{ (880000 * 0.02 - 1 * 8760 * capacity_factors.pv) * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 2% from [@JRC:2014] Table 9
-                om_prod: {{ 1 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} stolen from om_annual for technical reasons
     wind:
         essentials:
             name: Wind
@@ -29,12 +23,6 @@ tech_groups:
         constraints:
             resource: file=capacityfactors-wind-onshore.csv
             resource_unit: energy_per_cap
-            lifetime: 25 # [@JRC:2014] Table 4
-        costs:
-            monetary:
-                energy_cap: {{ 1100000 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} from [@JRC:2014] Table 4
-                om_annual: {{ (1100000 * 0.017 - 1 * 8760 * capacity_factors.onshore) * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 1.7% from [@JRC:2014] Table 4
-                om_prod: {{ 1 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} stolen from om_annual for technical reasons
 
 techs:
     open_field_pv:
@@ -48,11 +36,6 @@ techs:
             resource_area_max: inf # see https://github.com/calliope-project/calliope/pull/160
             resource: file=capacityfactors-open-field-pv.csv
             resource_unit: energy_per_cap
-        costs:
-            monetary:
-                energy_cap: {{ 520000 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} from [@JRC:2014] Table 7
-                om_annual: {{ (520000 * 0.017 - 1 * 8760 * capacity_factors.pv) * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 1.7% from [@JRC:2014] Table 7
-                om_prod: {{ 1 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} stolen from om_annual for technical reasons
     roof_mounted_pv:
         essentials:
             name: Roof mounted PV
@@ -80,12 +63,6 @@ techs:
         constraints:
             resource: file=capacityfactors-wind-offshore.csv
             resource_unit: energy_per_cap
-            lifetime: 30 # [@JRC:2014] Table 5
-        costs:
-            monetary:
-                energy_cap: {{ 2280000 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} from [@JRC:2014] Table 5
-                om_annual: {{ (2280000 * 0.023 - 1 * 8760 * capacity_factors.offshore) * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 2.3% from [@JRC:2014] Table 5
-                om_prod: {{ 1 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} stolen from om_annual for technical reasons
     load_shedding:
         essentials:
             name: Load shedding as last resort
@@ -105,11 +82,6 @@ techs:
             resource: file=capacityfactors-hydro-ror.csv
             resource_unit: energy_per_cap
             lifetime: 60
-        costs:
-            monetary:
-                energy_cap: {{ 5620000 * scaling_factors.specific_costs }}  # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 2013 EUR/MW] from [@JRC:2014] Table 14
-                om_prod: {{ 5 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW/yr") }} from [@JRC:2014] Table 14
-                om_annual: {{ 5620000 * 0.03 * scaling_factors.specific_costs }}  # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW/yr") }} 3% from [@JRC:2014] Table 14
     hydro_reservoir:
         essentials:
             name: Hydro electricity with a reservoir.
@@ -119,22 +91,11 @@ techs:
             resource: file=capacityfactors-hydro-reservoir-inflow.csv
             resource_unit: energy_per_cap
             lifetime: 60
-        costs:
-            monetary:
-                energy_cap: {{ 3370000 * scaling_factors.specific_costs }}  # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} from [@JRC:2014] Table 12
-                om_prod: {{ 5 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW/yr") }} from [@JRC:2014] Table 12
-                om_annual: {{ 3370000 * 0.03 * scaling_factors.specific_costs }}  # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW/yr") }} from [@JRC:2014] Table 12
-    biofuel: # based on Anaerobic digestion from [@JRC:2014] Table 48
+    biofuel: 
         essentials:
             name: Biofuel
             parent: supply_plus
             carrier: electricity
         constraints:
             energy_eff: 1.0 # efficiency modelled within the input resource stream to avoid poor numerical scaling
-            lifetime: 20
-        costs:
-            monetary:
-                energy_cap: {{ 2300000 * scaling_factors.specific_costs }}  # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
-                om_prod: 0 # 3.1 (EUR2013/MWh) added to om_con, because value is very small and causing poor numerical range
-                om_annual: {{ 2300000 * 0.041 * scaling_factors.specific_costs }}  # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW/yr") }} 2300000 * 4.1%
-                om_con: {{ (biofuel_fuel_cost / biofuel_efficiency + 3.1) * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR/MWh") }}
+

--- a/templates/renewable-techs.yaml
+++ b/templates/renewable-techs.yaml
@@ -63,16 +63,6 @@ techs:
         constraints:
             resource: file=capacityfactors-wind-offshore.csv
             resource_unit: energy_per_cap
-    load_shedding:
-        essentials:
-            name: Load shedding as last resort
-            parent: supply
-            carrier: electricity
-        constraints:
-            energy_cap_max: inf
-        costs:
-            monetary:
-                om_prod: {{ 8000 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR/MWh") }}
     hydro_run_of_river:
         essentials:
             name: Run of river hydro electricity
@@ -81,7 +71,6 @@ techs:
         constraints:
             resource: file=capacityfactors-hydro-ror.csv
             resource_unit: energy_per_cap
-            lifetime: 60
     hydro_reservoir:
         essentials:
             name: Hydro electricity with a reservoir.
@@ -90,7 +79,6 @@ techs:
         constraints:
             resource: file=capacityfactors-hydro-reservoir-inflow.csv
             resource_unit: energy_per_cap
-            lifetime: 60
     biofuel: 
         essentials:
             name: Biofuel

--- a/templates/storage-techs.yaml
+++ b/templates/storage-techs.yaml
@@ -1,5 +1,5 @@
 techs:
-    battery: # based on [@Schmidt:2019]
+    battery:
         essentials:
             name: 'Battery storage'
             parent: storage
@@ -7,7 +7,7 @@ techs:
         constraints:
             energy_cap_max: inf
             storage_cap_max: inf
-    pumped_hydro: # based on [@Schmidt:2019]
+    pumped_hydro:
         essentials:
             name: 'Pumped hydro power storage'
             parent: storage
@@ -15,7 +15,7 @@ techs:
         constraints:
             energy_cap_max: inf
             storage_cap_max: inf
-    hydrogen: # based on [@Schmidt:2019]
+    hydrogen:
         essentials:
             name: Hydrogen power storage
             parent: storage

--- a/templates/storage-techs.yaml
+++ b/templates/storage-techs.yaml
@@ -7,15 +7,6 @@ techs:
         constraints:
             energy_cap_max: inf
             storage_cap_max: inf
-            energy_eff: 0.9273  # 0.86 round trip efficiency
-            storage_loss: 0  # No loss over time assumed
-            lifetime: 10
-        costs:
-            monetary:
-                storage_cap: {{ 723130 * 0.14 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}, 802 $2015
-                energy_cap: {{ 611324 * 0.14 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}, 678 $2015
-                om_annual: {{ 9016 * 0.14 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW/year") }}, 10 $2015
-                om_prod: {{ 2.7 * 0.14 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}, 3 $2015
     pumped_hydro: # based on [@Schmidt:2019]
         essentials:
             name: 'Pumped hydro power storage'
@@ -24,14 +15,6 @@ techs:
         constraints:
             energy_cap_max: inf
             storage_cap_max: inf
-            energy_eff: 0.8832 # 0.78 round-trip
-            lifetime: 55
-        costs:
-            monetary:
-                storage_cap: {{ 72133 * 1.02 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}, 80 $2015
-                energy_cap: {{ 1017973 * 1.02 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}, 1129 $2015
-                om_annual: {{ 7213 * 1.02 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW/year") }}, 8 $2015
-                om_prod: {{ 1 * 1.02 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}, 1 $2015, rounded to 1€ for numeric range
     hydrogen: # based on [@Schmidt:2019]
         essentials:
             name: Hydrogen power storage
@@ -40,11 +23,3 @@ techs:
         constraints:
             energy_cap_max: inf
             storage_cap_max: inf
-            energy_eff: 0.6325  # 0.40 round-trip
-            lifetime: 15
-        costs:
-            monetary:
-                storage_cap: {{ 27951 * 0.33 * scaling_factors.specific_costs }}  # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}, 31 $2015
-                energy_cap: {{ 4884287 * 0.33 * scaling_factors.specific_costs }}  # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}, 5417 $2015
-                om_annual: {{ 41476 * 0.33 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW/year") }}, 46 $2015
-                om_prod: 0

--- a/templates/tech-costs.yaml
+++ b/templates/tech-costs.yaml
@@ -1,4 +1,50 @@
+tech_groups: # Generation from [@JRC:2014]
+    pv_on_roof:  # Table 9
+        constraints.lifetime: 25
+        costs.monetary:
+            energy_cap: {{ 880000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
+            om_annual: {{ (880000 * 0.02 - 1 * 8760 * capacity_factors.pv) * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 2% of CAPEX
+            om_prod: {{1 * scaling_factors.specific_costs}} # stolen from om_annual for technical reasons
+    wind_onshore: # Table 4
+        constraints.lifetime: 25
+        costs.monetary:
+            energy_cap: {{ 1100000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
+            om_annual: {{ (1100000 * 0.017 - 1 * 8760 * capacity_factors.onshore) * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 1.7% of CAPEX
+            om_prod: {{1 * scaling_factors.specific_costs}} # stolen from om_annual for technical reasons
 techs:
+    # Generation from [@JRC:2014]
+    open_field_pv: # Table 7
+        constraints.lifetime: 25
+        costs.monetary:
+            energy_cap: {{ 520000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
+            om_annual: {{ (520000 * 0.017 - 1 * 8760 * capacity_factors.pv) * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 1.7% of CAPEX
+            om_prod: {{1 * scaling_factors.specific_costs}} # stolen from om_annual for technical reasons
+    wind_offshore: # Table 5
+        constraints.lifetime: 30
+        costs.monetary:
+            energy_cap: {{ 2280000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
+            om_annual: {{ (2280000 * 0.023 - 1 * 8760 * capacity_factors.offshore) * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 2.3% of CAPEX
+            om_prod: {{1 * scaling_factors.specific_costs}} # stolen from om_annual for technical reasons
+    biofuel: # Table 48 Anaerobic digestion
+        constraints.lifetime: 20
+        costs.monetary:
+            energy_cap: {{2300000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
+            om_annual: {{2300000 * 0.041 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 4.1% of CAPEX
+            om_con: {{ (biofuel_fuel_cost / biofuel_efficiency + 3.1) * scaling_factors.specific_costs }} # unit("EUR2013/MWh")
+            om_prod: 0 # 3.1 (EUR2013/MWh) added to om_con because value is very small and causing poor numerical range
+    hydro_run_of_river: # Table 14
+        constraints.lifetime: 60
+        costs.monetary:
+            energy_cap: {{5620000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
+            om_annual: {{5620000 * 0.03 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 3% of CAPEX
+            om_prod: {{5 * scaling_factors.specific_costs}} # unit("EUR2013/MWh)") 
+    hydro_reservoir: # Table 12
+        constraints.lifetime: 60
+        costs.monetary:
+            energy_cap: {{3370000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
+            om_annual: {{3370000 * 0.03 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 3% of CAPEX
+            om_prod: {{5 * scaling_factors.specific_costs}} #  unit("EUR2013/MWh)") 
+    load_shedding.costs.monetary.om_prod: {{ 8000 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR/MWh") }}
     # Storage from [@schmidt:2019] Table S4
     battery.costs.monetary:
         storage_cap: {{ 723130 * 0.14 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}, 802 $2015
@@ -65,49 +111,6 @@ overrides:
                 om_annual: {{ 37800 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW/year") }}
                 om_prod: 0 # 1.3 (EUR2015/MWh) added to om_con because value is very small and causing poor numerical range
                 om_con: {{ (biofuel_fuel_cost / biofuel_efficiency + 1.3) * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}
-    etri-renewable-cost: # from [@JRC:2014]
-        tech_groups.pv_on_roof:  # Table 9
-            constraints.lifetime: 25
-            costs.monetary:
-                energy_cap: {{ 880000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
-                om_annual: {{ (880000 * 0.02 - 1 * 8760 * capacity_factors.pv) * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 2% of CAPEX
-                om_prod: {{1 * scaling_factors.specific_costs}} # stolen from om_annual for technical reasons
-        techs.open_field_pv: # Table 7
-            constraints.lifetime: 25
-            costs.monetary:
-                energy_cap: {{ 520000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
-                om_annual: {{ (520000 * 0.017 - 1 * 8760 * capacity_factors.pv) * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 1.7% of CAPEX
-                om_prod: {{1 * scaling_factors.specific_costs}} # stolen from om_annual for technical reasons
-        tech_groups.wind_onshore: # Table 4
-            constraints.lifetime: 25
-            costs.monetary:
-                energy_cap: {{ 1100000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
-                om_annual: {{ (1100000 * 0.017 - 1 * 8760 * capacity_factors.onshore) * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 1.7% of CAPEX
-                om_prod: {{1 * scaling_factors.specific_costs}} # stolen from om_annual for technical reasons
-        techs.wind_offshore: # Table 5
-            constraints.lifetime: 30
-            costs.monetary:
-                energy_cap: {{ 2280000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
-                om_annual: {{ (2280000 * 0.023 - 1 * 8760 * capacity_factors.offshore) * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 2.3% of CAPEX
-                om_prod: {{1 * scaling_factors.specific_costs}} # stolen from om_annual for technical reasons
-        techs.biofuel: # Table 48 Anaerobic digestion
-            constraints.lifetime: 20
-            costs.monetary:
-                energy_cap: {{2300000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
-                om_annual: {{2300000 * 0.041 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 4.1% of CAPEX
-                om_con: {{ (biofuel_fuel_cost / biofuel_efficiency + 3.1) * scaling_factors.specific_costs }} # unit("EUR2013/MWh")
-                om_prod: 0 # 3.1 (EUR2013/MWh) added to om_con because value is very small and causing poor numerical range
-    etri-hydro-cost: # from [@JRC:2014]
-        techs.hydro_run_of_river.costs.monetary: # Table 14
-            energy_cap: {{5620000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
-            om_annual: {{5620000 * 0.03 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 3% of CAPEX
-            om_prod: {{5 * scaling_factors.specific_costs}} # unit("EUR2013/MWh)") 
-        techs.hydro_run_of_river.constraints.lifetime: 60
-        techs.hydro_reservoir.costs.monetary: # Table 12
-            energy_cap: {{3370000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
-            om_annual: {{3370000 * 0.03 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 3% of CAPEX
-            om_prod: {{5 * scaling_factors.specific_costs}} #  unit("EUR2013/MWh)") 
-        techs.hydro_reservoir.constraints.lifetime: 60
     schroeder-hydro-cost: # from [@schroeder:2013]
         techs.hydro_run_of_river.costs.monetary:
             energy_cap: {{3000000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2010/MW") }} Table 33
@@ -119,54 +122,16 @@ overrides:
             om_annual: {{ 20000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2010/MW") }} Table 34
             om_prod: 0 # Table 34
         techs.hydro_reservoir.constraints.lifetime: 60
-    no-hydro-cost: 
-        # Only assign costs to O&M and variable costs (from [#JRC:2014])
+    no-hydro-fixed-cost: 
+        # Only assign costs to O&M and variable costs
         # since hydro is constrained to current capacities
-        techs.pumped_hydro.costs.monetary.storage_cap: 0
-        techs.pumped_hydro.costs.monetary.energy_cap: 0
-        techs.hydro_run_of_river.costs.monetary: # Table 14
+        techs.pumped_hydro.costs.monetary:
+            storage_cap: 0
             energy_cap: 0
-            om_annual: {{5620000 * 0.03 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 3% of CAPEX
-            om_prod: {{5 * scaling_factors.specific_costs}} # unit("EUR2013/MWh)") 
+        techs.hydro_run_of_river.costs.monetary:
+            energy_cap: 0
             om_con: 0
-        techs.hydro_run_of_river.constraints.lifetime: 60
-        techs.hydro_reservoir.costs.monetary: # Table 12
+        techs.hydro_reservoir.costs.monetary:
             energy_cap: 0
             storage_cap: 0
-            om_annual: {{3370000 * 0.03 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 3% of CAPEX
-            om_prod: {{5 * scaling_factors.specific_costs}} #  unit("EUR2013/MWh)") 
             om_con: 0
-        techs.hydro_reservoir.constraints.lifetime: 60
-    load-shedding: # allowing for an option for load shedding
-        techs.load_shedding:
-            essentials:
-                name: Load shedding as last resort
-                parent: supply
-                carrier: electricity
-            constraints:
-                energy_cap_max: inf
-            costs:
-                monetary:
-                    om_prod: {{ 8000 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR/MWh") }}
-    schmidt-storage-cost:
-        techs.battery.costs.monetary:
-            storage_cap: {{723130 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}
-            energy_cap: {{611324 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}
-            om_annual: {{9016 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}
-            om_prod: {{2.7 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}
-        techs.pumped_hydro.costs.monetary:
-            storage_cap: {{72133 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}
-            energy_cap: {{1017973 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}
-            om_annual: {{7213 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}
-            om_prod: {{1 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}
-        techs.hydrogen.costs.monetary:
-            storage_cap: {{27951 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}
-            energy_cap: {{4884287 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}
-            om_annual: {{41476 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}
-            om_prod: 0 
-    stylised-storage:
-        # Transform battery and hydrogen to stylised short-term 
-        # and long-term storage solutions
-        techs.battery.constraints.energy_cap_per_storage_cap_min: 0.25 #max 4h full-power discharge
-        techs.battery.costs.monetary.om_prod: 0 # Assume 0 instead of 0.000378 EUR/k"h as tiny value causes numerical issues
-        techs.hydrogen.constraints.energy_cap_per_storage_cap_max: 0.25 #min 4h full-power discharge

--- a/templates/tech-costs.yaml
+++ b/templates/tech-costs.yaml
@@ -1,82 +1,86 @@
-tech_groups: # Generation from [@JRC:2014]
-    pv_on_roof:  # Table 9
+tech_groups:
+    pv_on_roof:  # from [@JRC:2014] Table 9
         constraints.lifetime: 25
         costs.monetary:
             energy_cap: {{ 880000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
             om_annual: {{ (880000 * 0.02 - 1 * 8760 * capacity_factors.pv) * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 2% of CAPEX
             om_prod: {{1 * scaling_factors.specific_costs}} # stolen from om_annual for technical reasons
-    wind_onshore: # Table 4
+    wind_onshore: # from [@JRC:2014] Table 4
         constraints.lifetime: 25
         costs.monetary:
             energy_cap: {{ 1100000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
             om_annual: {{ (1100000 * 0.017 - 1 * 8760 * capacity_factors.onshore) * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 1.7% of CAPEX
             om_prod: {{1 * scaling_factors.specific_costs}} # stolen from om_annual for technical reasons
 techs:
-    # Generation from [@JRC:2014]
-    open_field_pv: # Table 7
+    open_field_pv: # from [@JRC:2014] Table 7
         constraints.lifetime: 25
         costs.monetary:
             energy_cap: {{ 520000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
             om_annual: {{ (520000 * 0.017 - 1 * 8760 * capacity_factors.pv) * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 1.7% of CAPEX
             om_prod: {{1 * scaling_factors.specific_costs}} # stolen from om_annual for technical reasons
-    wind_offshore: # Table 5
+    wind_offshore: # from [@JRC:2014] Table 5
         constraints.lifetime: 30
         costs.monetary:
             energy_cap: {{ 2280000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
             om_annual: {{ (2280000 * 0.023 - 1 * 8760 * capacity_factors.offshore) * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 2.3% of CAPEX
             om_prod: {{1 * scaling_factors.specific_costs}} # stolen from om_annual for technical reasons
-    biofuel: # Table 48 Anaerobic digestion
+    biofuel: # from [@JRC:2014] Table 48 Anaerobic digestion
         constraints.lifetime: 20
         costs.monetary:
             energy_cap: {{2300000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
             om_annual: {{2300000 * 0.041 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 4.1% of CAPEX
             om_con: {{ (biofuel_fuel_cost / biofuel_efficiency + 3.1) * scaling_factors.specific_costs }} # unit("EUR2013/MWh")
             om_prod: 0 # 3.1 (EUR2013/MWh) added to om_con because value is very small and causing poor numerical range
-    hydro_run_of_river: # Table 14
+    hydro_run_of_river: # from [@JRC:2014] Table 14
         constraints.lifetime: 60
         costs.monetary:
             energy_cap: {{5620000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
             om_annual: {{5620000 * 0.03 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 3% of CAPEX
             om_prod: {{5 * scaling_factors.specific_costs}} # unit("EUR2013/MWh)") 
-    hydro_reservoir: # Table 12
+    hydro_reservoir: # from [@JRC:2014] Table 12
         constraints.lifetime: 60
         costs.monetary:
             energy_cap: {{3370000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
             om_annual: {{3370000 * 0.03 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 3% of CAPEX
             om_prod: {{5 * scaling_factors.specific_costs}} #  unit("EUR2013/MWh)") 
-    load_shedding.costs.monetary.om_prod: {{ 8000 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR/MWh") }}
-    # Storage from [@schmidt:2019] Table S4
-    battery.costs.monetary:
-        storage_cap: {{ 723130 * 0.14 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}, 802 $2015
-        energy_cap: {{ 611324 * 0.14 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}, 678 $2015
-        om_annual: {{ 9016 * 0.14 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW/year") }}, 10 $2015
-        om_prod: {{ 2.7 * 0.14 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}, 3 $2015
-    battery.constraints:
-        energy_eff: 0.9273  # 0.86 round trip efficiency
-        storage_loss: 0  # No loss over time assumed
-        lifetime: 10
-    pumped_hydro.costs.monetary:
-        storage_cap: {{ 72133 * 1.02 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}, 80 $2015
-        energy_cap: {{ 1017973 * 1.02 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}, 1129 $2015
-        om_annual: {{ 7213 * 1.02 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW/year") }}, 8 $2015
-        om_prod: {{ 1 * 1.02 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}, 1 $2015, rounded to 1€ for numeric range
-    pumped_hydro.constraints:
-        energy_eff: 0.8832 # 0.78 round-trip
-        lifetime: 55
-    hydrogen.costs.monetary:
-        storage_cap: {{ 27951 * 0.33 * scaling_factors.specific_costs }}  # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}, 31 $2015
-        energy_cap: {{ 4884287 * 0.33 * scaling_factors.specific_costs }}  # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}, 5417 $2015
-        om_annual: {{ 41476 * 0.33 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW/year") }}, 46 $2015
-        om_prod: 0
-    hydrogen.constraints:
-        energy_eff: 0.6325  # 0.40 round-trip
-        lifetime: 15
-    # Transmission from [@JRC:2014], Table 39
-    free_transmission.costs.monetary.om_prod: 0
-    ac_transmission.costs.monetary:
-        energy_cap_per_distance: {{ 0.9 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW/m") }}
-        om_annual_investment_fraction: 0.015
-    ac_transmission.constraints.lifetime: 60
+    load_shedding:
+        costs.monetary:
+            om_prod: {{ 8000 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR/MWh") }}
+    battery: # from [@schmidt:2019] Table S4
+        costs.monetary:
+            storage_cap: {{ 723130 * 0.14 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}, 802 $2015
+            energy_cap: {{ 611324 * 0.14 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}, 678 $2015
+            om_annual: {{ 9016 * 0.14 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW/year") }}, 10 $2015
+            om_prod: {{ 2.7 * 0.14 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}, 3 $2015
+        constraints:
+            energy_eff: 0.9273  # 0.86 round trip efficiency
+            storage_loss: 0  # No loss over time assumed
+            lifetime: 10
+    pumped_hydro: # from [@schmidt:2019] Table S4
+        costs.monetary:
+            storage_cap: {{ 72133 * 1.02 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}, 80 $2015
+            energy_cap: {{ 1017973 * 1.02 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}, 1129 $2015
+            om_annual: {{ 7213 * 1.02 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW/year") }}, 8 $2015
+            om_prod: {{ 1 * 1.02 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}, 1 $2015, rounded to 1€ for numeric range
+        constraints:
+            energy_eff: 0.8832 # 0.78 round-trip
+            lifetime: 55
+    hydrogen: # from [@schmidt:2019] Table S4
+        costs.monetary:
+            storage_cap: {{ 27951 * 0.33 * scaling_factors.specific_costs }}  # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}, 31 $2015
+            energy_cap: {{ 4884287 * 0.33 * scaling_factors.specific_costs }}  # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}, 5417 $2015
+            om_annual: {{ 41476 * 0.33 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW/year") }}, 46 $2015
+            om_prod: 0
+        constraints:
+            energy_eff: 0.6325  # 0.40 round-trip
+            lifetime: 15
+    free_transmission:
+        costs.monetary.om_prod: 0
+    ac_transmission: # from [@JRC:2014], Table 39
+        constraints.lifetime: 60
+        costs.monetary:
+            energy_cap_per_distance: {{ 0.9 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW/m") }}
+            om_annual_investment_fraction: 0.015
 
 overrides:
     dea-renewable-cost: # from [@DEA:2020]
@@ -112,19 +116,20 @@ overrides:
                 om_prod: 0 # 1.3 (EUR2015/MWh) added to om_con because value is very small and causing poor numerical range
                 om_con: {{ (biofuel_fuel_cost / biofuel_efficiency + 1.3) * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}
     schroeder-hydro-cost: # from [@schroeder:2013]
-        techs.hydro_run_of_river.costs.monetary:
-            energy_cap: {{3000000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2010/MW") }} Table 33
-            om_annual: {{60000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2010/MW") }} Table 34
-            om_prod: 0 # Table 34
-        techs.hydro_run_of_river.constraints.lifetime: 60
-        techs.hydro_reservoir.costs.monetary:
-            energy_cap: {{ 2000000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2010/MW") }} Table 33
-            om_annual: {{ 20000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2010/MW") }} Table 34
-            om_prod: 0 # Table 34
-        techs.hydro_reservoir.constraints.lifetime: 60
+        techs.hydro_run_of_river:
+            constraints.lifetime: 60
+            costs.monetary:
+                energy_cap: {{3000000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2010/MW") }} Table 33
+                om_annual: {{60000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2010/MW") }} Table 34
+                om_prod: 0 # Table 34
+        techs.hydro_reservoir:
+            constraints.lifetime: 60
+            costs.monetary:
+                energy_cap: {{ 2000000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2010/MW") }} Table 33
+                om_annual: {{ 20000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2010/MW") }} Table 34
+                om_prod: 0 # Table 34
     no-hydro-fixed-cost: 
         # Only assign costs to O&M and variable costs
-        # since hydro is constrained to current capacities
         techs.pumped_hydro.costs.monetary:
             storage_cap: 0
             energy_cap: 0

--- a/templates/tech-costs.yaml
+++ b/templates/tech-costs.yaml
@@ -4,45 +4,45 @@ tech_groups:
         costs.monetary:
             energy_cap: {{ 880000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
             om_annual: {{ (880000 * 0.02 - 1 * 8760 * capacity_factors.pv) * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 2% of CAPEX
-            om_prod: {{1 * scaling_factors.specific_costs}} # stolen from om_annual for technical reasons
+            om_prod: {{1 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} stolen from om_annual for technical reasons
     wind_onshore: # from [@JRC:2014] Table 4
         constraints.lifetime: 25
         costs.monetary:
             energy_cap: {{ 1100000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
             om_annual: {{ (1100000 * 0.017 - 1 * 8760 * capacity_factors.onshore) * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 1.7% of CAPEX
-            om_prod: {{1 * scaling_factors.specific_costs}} # stolen from om_annual for technical reasons
+            om_prod: {{1 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} stolen from om_annual for technical reasons
 techs:
     open_field_pv: # from [@JRC:2014] Table 7
         constraints.lifetime: 25
         costs.monetary:
             energy_cap: {{ 520000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
             om_annual: {{ (520000 * 0.017 - 1 * 8760 * capacity_factors.pv) * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 1.7% of CAPEX
-            om_prod: {{1 * scaling_factors.specific_costs}} # stolen from om_annual for technical reasons
+            om_prod: {{1 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} stolen from om_annual for technical reasons
     wind_offshore: # from [@JRC:2014] Table 5
         constraints.lifetime: 30
         costs.monetary:
             energy_cap: {{ 2280000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
             om_annual: {{ (2280000 * 0.023 - 1 * 8760 * capacity_factors.offshore) * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 2.3% of CAPEX
-            om_prod: {{1 * scaling_factors.specific_costs}} # stolen from om_annual for technical reasons
+            om_prod: {{1 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} stolen from om_annual for technical reasons
     biofuel: # from [@JRC:2014] Table 48 Anaerobic digestion
         constraints.lifetime: 20
         costs.monetary:
             energy_cap: {{2300000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
             om_annual: {{2300000 * 0.041 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 4.1% of CAPEX
-            om_con: {{ (biofuel_fuel_cost / biofuel_efficiency + 3.1) * scaling_factors.specific_costs }} # unit("EUR2013/MWh")
+            om_con: {{ (biofuel_fuel_cost / biofuel_efficiency + 3.1) * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
             om_prod: 0 # 3.1 (EUR2013/MWh) added to om_con because value is very small and causing poor numerical range
     hydro_run_of_river: # from [@JRC:2014] Table 14
         constraints.lifetime: 60
         costs.monetary:
             energy_cap: {{5620000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
             om_annual: {{5620000 * 0.03 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 3% of CAPEX
-            om_prod: {{5 * scaling_factors.specific_costs}} # unit("EUR2013/MWh)") 
+            om_prod: {{5 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 
     hydro_reservoir: # from [@JRC:2014] Table 12
         constraints.lifetime: 60
         costs.monetary:
             energy_cap: {{3370000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
             om_annual: {{3370000 * 0.03 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 3% of CAPEX
-            om_prod: {{5 * scaling_factors.specific_costs}} #  unit("EUR2013/MWh)") 
+            om_prod: {{5 * scaling_factors.specific_costs}} #  {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 
     load_shedding:
         costs.monetary:
             om_prod: {{ 8000 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR/MWh") }}
@@ -84,50 +84,50 @@ techs:
 
 overrides:
     dea-renewable-cost: # from [@DEA:2020]
-        tech_groups.pv_on_roof: #  Sheet 22 - Photovoltaics Small (2016)
-            constraints.lifetime: 40 
+        tech_groups.pv_on_roof: #  Sheet 22 - Photovoltaics Small (last updated 2016)
+            constraints.lifetime: 40 # inverter lifetime is shorter but the replacement cost is included in O&M
             costs.monetary:
-                energy_cap: {{ 560000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}
-                om_annual: {{ (8700  - 1 * 8760 * capacity_factors.pv) * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}
-                om_prod: {{1 * scaling_factors.specific_costs}} # stolen from om_annual for technical reasons
-        techs.open_field_pv: # Sheet 22 - Photovoltaics Large (2016)
-            constraints.lifetime: 40
+                energy_cap: {{ 587500 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}
+                om_annual: {{ (9135  - 1 * 8760 * capacity_factors.pv) * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}
+                om_prod: {{1 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }} stolen from om_annual for technical reasons
+        techs.open_field_pv: # Sheet 22 - Photovoltaics Large (last updated 2016)
+            constraints.lifetime: 40 # inverter lifetime is shorter but the replacement cost is included in O&M
             costs.monetary:
-                energy_cap: {{ 241000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}
-                om_annual: {{ (5000 - 1 * 8760 * capacity_factors.pv) * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW/year") }}
-                om_prod: {{1 * scaling_factors.specific_costs}} # stolen from om_annual for technical reasons
-        tech_groups.wind_onshore: # Sheet 20 Onshore Turbines (2019)
+                energy_cap: {{ 241000 * 1.25 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }} with DC/AC sizing factor
+                om_annual: {{ (5000 * 1.25 - 1 * 8760 * capacity_factors.pv) * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW/year") }} with DC/AC sizing factor
+                om_prod: {{ 1 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }} stolen from om_annual for technical reasons
+        tech_groups.wind_onshore: # Sheet 20 Onshore Turbines (last updated 2019)
             constraints.lifetime: 30
             costs.monetary:
                 energy_cap: {{ 963000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}
                 om_annual: {{ (11340 - 1 * 8760 * capacity_factors.onshore) * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW/year") }}
-                om_prod: {{1 * scaling_factors.specific_costs}} #stolen from om_annual for technical reasons
-        techs.wind_offshore: # Sheet 21 Offshore Turbines (2019)
+                om_prod: {{ 1 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }} stolen from om_annual for technical reasons
+        techs.wind_offshore: # Sheet 21 Offshore Turbines (last updated 2019)
             constraints.lifetime: 30
             costs.monetary:
                 energy_cap: {{ 1777000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}
                 om_annual: {{ (32448 - 1 * 8760 * capacity_factors.offshore) * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW/year") }}
-                om_prod: {{1 * scaling_factors.specific_costs}} # stolen from om_annual for technical reasons
-        techs.biofuel:  # Sheet 09a Wood Chips, Medium (CHP with 80MW feed) (2020)
+                om_prod: {{ 1 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }} stolen from om_annual for technical reasons
+        techs.biofuel:  # Sheet 06 Gas engines, biogas (last updated 2018) and [@DEA:2017] Sheet 81 Biogas Plant, Basic conf. (last updated 2017)
             constraints.lifetime: 25
-            costs.monetary:
-                energy_cap: {{ 935800 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}
-                om_annual: {{ 37800 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW/year") }}
-                om_prod: 0 # 1.3 (EUR2015/MWh) added to om_con because value is very small and causing poor numerical range
-                om_con: {{ (biofuel_fuel_cost / biofuel_efficiency + 1.3) * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}
+            costs.monetary: 
+                energy_cap: {{ (850000 + 1386000) * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}
+                om_annual: {{ (8500 + 178500) * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW/year") }}
+                om_prod: 0 # 6 (EUR2015/MWh) added to om_con because value is very small and causing poor numerical range
+                om_con: {{ (biofuel_fuel_cost / biofuel_efficiency + 6) * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}
     schroeder-hydro-cost: # from [@schroeder:2013]
         techs.hydro_run_of_river:
             constraints.lifetime: 60
             costs.monetary:
-                energy_cap: {{3000000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2010/MW") }} Table 33
-                om_annual: {{60000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2010/MW") }} Table 34
-                om_prod: 0 # Table 34
+                energy_cap: {{ 3000000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2010/MW") }} Table 33
+                om_annual: {{ (60000 - 1 * 8760 * capacity_factors.ror) * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2010/MW") }} Table 34
+                om_prod: {{ 1 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2010/MW") }} stolen from om_annual for technical reasons
         techs.hydro_reservoir:
             constraints.lifetime: 60
             costs.monetary:
                 energy_cap: {{ 2000000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2010/MW") }} Table 33
-                om_annual: {{ 20000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2010/MW") }} Table 34
-                om_prod: 0 # Table 34
+                om_annual: {{ (20000 - 1 * 8760 * capacity_factors.ror) * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2010/MW") }} Table 34
+                om_prod: {{ 1 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2010/MW") }} stolen from om_annual for technical reasons
     no-hydro-fixed-cost: 
         # Only assign costs to O&M and variable costs
         techs.pumped_hydro.costs.monetary:

--- a/templates/tech-costs.yaml
+++ b/templates/tech-costs.yaml
@@ -1,3 +1,37 @@
+techs:
+    # Storage from [@schmidt:2019] Table S4
+    battery.costs.monetary:
+        storage_cap: {{ 723130 * 0.14 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}, 802 $2015
+        energy_cap: {{ 611324 * 0.14 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}, 678 $2015
+        om_annual: {{ 9016 * 0.14 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW/year") }}, 10 $2015
+        om_prod: {{ 2.7 * 0.14 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}, 3 $2015
+    battery.constraints:
+        energy_eff: 0.9273  # 0.86 round trip efficiency
+        storage_loss: 0  # No loss over time assumed
+        lifetime: 10
+    pumped_hydro.costs.monetary:
+        storage_cap: {{ 72133 * 1.02 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}, 80 $2015
+        energy_cap: {{ 1017973 * 1.02 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}, 1129 $2015
+        om_annual: {{ 7213 * 1.02 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW/year") }}, 8 $2015
+        om_prod: {{ 1 * 1.02 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}, 1 $2015, rounded to 1€ for numeric range
+    pumped_hydro.constraints:
+        energy_eff: 0.8832 # 0.78 round-trip
+        lifetime: 55
+    hydrogen.costs.monetary:
+        storage_cap: {{ 27951 * 0.33 * scaling_factors.specific_costs }}  # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}, 31 $2015
+        energy_cap: {{ 4884287 * 0.33 * scaling_factors.specific_costs }}  # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}, 5417 $2015
+        om_annual: {{ 41476 * 0.33 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW/year") }}, 46 $2015
+        om_prod: 0
+    hydrogen.constraints:
+        energy_eff: 0.6325  # 0.40 round-trip
+        lifetime: 15
+    # Transmission from [@JRC:2014], Table 39
+    free_transmission.costs.monetary.om_prod: 0
+    ac_transmission.costs.monetary:
+        energy_cap_per_distance: {{ 0.9 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW/m") }}
+        om_annual_investment_fraction: 0.015
+    ac_transmission.constraints.lifetime: 60
+
 overrides:
     dea-renewable-cost: # from [@DEA:2020]
         tech_groups.pv_on_roof: #  Sheet 22 - Photovoltaics Small (2016)
@@ -38,19 +72,19 @@ overrides:
                 energy_cap: {{ 880000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
                 om_annual: {{ (880000 * 0.02 - 1 * 8760 * capacity_factors.pv) * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 2% of CAPEX
                 om_prod: {{1 * scaling_factors.specific_costs}} # stolen from om_annual for technical reasons
-        techs.open_field_pv: #Table 7
+        techs.open_field_pv: # Table 7
             constraints.lifetime: 25
             costs.monetary:
                 energy_cap: {{ 520000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
                 om_annual: {{ (520000 * 0.017 - 1 * 8760 * capacity_factors.pv) * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 1.7% of CAPEX
                 om_prod: {{1 * scaling_factors.specific_costs}} # stolen from om_annual for technical reasons
-        tech_groups.wind_onshore: #Table 4
+        tech_groups.wind_onshore: # Table 4
             constraints.lifetime: 25
             costs.monetary:
                 energy_cap: {{ 1100000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
                 om_annual: {{ (1100000 * 0.017 - 1 * 8760 * capacity_factors.onshore) * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 1.7% of CAPEX
                 om_prod: {{1 * scaling_factors.specific_costs}} # stolen from om_annual for technical reasons
-        techs.wind_offshore: #Table 5
+        techs.wind_offshore: # Table 5
             constraints.lifetime: 30
             costs.monetary:
                 energy_cap: {{ 2280000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
@@ -68,20 +102,53 @@ overrides:
             energy_cap: {{5620000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
             om_annual: {{5620000 * 0.03 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 3% of CAPEX
             om_prod: {{5 * scaling_factors.specific_costs}} # unit("EUR2013/MWh)") 
+        techs.hydro_run_of_river.constraints.lifetime: 60
         techs.hydro_reservoir.costs.monetary: # Table 12
             energy_cap: {{3370000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }}
             om_annual: {{3370000 * 0.03 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 3% of CAPEX
             om_prod: {{5 * scaling_factors.specific_costs}} #  unit("EUR2013/MWh)") 
+        techs.hydro_reservoir.constraints.lifetime: 60
     schroeder-hydro-cost: # from [@schroeder:2013]
         techs.hydro_run_of_river.costs.monetary:
             energy_cap: {{3000000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2010/MW") }} Table 33
             om_annual: {{60000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2010/MW") }} Table 34
             om_prod: 0 # Table 34
+        techs.hydro_run_of_river.constraints.lifetime: 60
         techs.hydro_reservoir.costs.monetary:
             energy_cap: {{ 2000000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2010/MW") }} Table 33
             om_annual: {{ 20000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2010/MW") }} Table 34
             om_prod: 0 # Table 34
-    schmidt-storage-cost: # from [@schmidt:2019] Table S4
+        techs.hydro_reservoir.constraints.lifetime: 60
+    no-hydro-cost: 
+        # Only assign costs to O&M and variable costs (from [#JRC:2014])
+        # since hydro is constrained to current capacities
+        techs.pumped_hydro.costs.monetary.storage_cap: 0
+        techs.pumped_hydro.costs.monetary.energy_cap: 0
+        techs.hydro_run_of_river.costs.monetary: # Table 14
+            energy_cap: 0
+            om_annual: {{5620000 * 0.03 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 3% of CAPEX
+            om_prod: {{5 * scaling_factors.specific_costs}} # unit("EUR2013/MWh)") 
+            om_con: 0
+        techs.hydro_run_of_river.constraints.lifetime: 60
+        techs.hydro_reservoir.costs.monetary: # Table 12
+            energy_cap: 0
+            storage_cap: 0
+            om_annual: {{3370000 * 0.03 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2013/MW") }} 3% of CAPEX
+            om_prod: {{5 * scaling_factors.specific_costs}} #  unit("EUR2013/MWh)") 
+            om_con: 0
+        techs.hydro_reservoir.constraints.lifetime: 60
+    load-shedding: # allowing for an option for load shedding
+        techs.load_shedding:
+            essentials:
+                name: Load shedding as last resort
+                parent: supply
+                carrier: electricity
+            constraints:
+                energy_cap_max: inf
+            costs:
+                monetary:
+                    om_prod: {{ 8000 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR/MWh") }}
+    schmidt-storage-cost:
         techs.battery.costs.monetary:
             storage_cap: {{723130 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}
             energy_cap: {{611324 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}
@@ -97,4 +164,9 @@ overrides:
             energy_cap: {{4884287 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}
             om_annual: {{41476 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}
             om_prod: 0 
-
+    stylised-storage:
+        # Transform battery and hydrogen to stylised short-term 
+        # and long-term storage solutions
+        techs.battery.constraints.energy_cap_per_storage_cap_min: 0.25 #max 4h full-power discharge
+        techs.battery.costs.monetary.om_prod: 0 # Assume 0 instead of 0.000378 EUR/k"h as tiny value causes numerical issues
+        techs.hydrogen.constraints.energy_cap_per_storage_cap_max: 0.25 #min 4h full-power discharge

--- a/templates/tech-costs.yaml
+++ b/templates/tech-costs.yaml
@@ -108,13 +108,6 @@ overrides:
                 energy_cap: {{ 1777000 * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}
                 om_annual: {{ (32448 - 1 * 8760 * capacity_factors.offshore) * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW/year") }}
                 om_prod: {{ 1 * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }} stolen from om_annual for technical reasons
-        techs.biofuel:  # Sheet 06 Gas engines, biogas (last updated 2018) and [@DEA:2017] Sheet 81 Biogas Plant, Basic conf. (last updated 2017)
-            constraints.lifetime: 25
-            costs.monetary: 
-                energy_cap: {{ (850000 + 1386000) * scaling_factors.specific_costs}} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW") }}
-                om_annual: {{ (8500 + 178500) * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MW/year") }}
-                om_prod: 0 # 6 (EUR2015/MWh) added to om_con because value is very small and causing poor numerical range
-                om_con: {{ (biofuel_fuel_cost / biofuel_efficiency + 6) * scaling_factors.specific_costs }} # {{ (1 / scaling_factors.specific_costs) | unit("EUR2015/MWh") }}
     schroeder-hydro-cost: # from [@schroeder:2013]
         techs.hydro_run_of_river:
             constraints.lifetime: 60

--- a/tests/resources/continental/model.yaml
+++ b/tests/resources/continental/model.yaml
@@ -1,5 +1,6 @@
 import:
     - '../../../build/model/interest-rate.yaml'
+    - '../../../build/model/cost-overrides.yaml'
     - '../../../build/model/renewable-techs.yaml'
     - '../../../build/model/storage-techs.yaml'
     - '../../../build/model/link-techs.yaml'

--- a/tests/resources/continental/model.yaml
+++ b/tests/resources/continental/model.yaml
@@ -1,6 +1,6 @@
 import:
     - '../../../build/model/interest-rate.yaml'
-    - '../../../build/model/cost-overrides.yaml'
+    - '../../../build/model/tech-costs.yaml'
     - '../../../build/model/renewable-techs.yaml'
     - '../../../build/model/storage-techs.yaml'
     - '../../../build/model/link-techs.yaml'

--- a/tests/resources/continental/model.yaml
+++ b/tests/resources/continental/model.yaml
@@ -15,7 +15,8 @@ model:
 scenarios:
     default: []
     directional-pv: ["directional-rooftop-pv"]
-    frozen-hydro: ["freeze-hydro-capacities"]
+    frozen-hydro: ["freeze-hydro-capacities", "no-hydro-fixed-cost"]
+    alternative-cost: ["dea-renewable-cost", "schroeder-hydro-cost"]
 run:
     solver: gurobi
     solver_io: python

--- a/tests/resources/national/model.yaml
+++ b/tests/resources/national/model.yaml
@@ -1,5 +1,6 @@
 import:
     - '../../../build/model/interest-rate.yaml'
+    - '../../../build/model/cost-overrides.yaml'
     - '../../../build/model/renewable-techs.yaml'
     - '../../../build/model/storage-techs.yaml'
     - '../../../build/model/link-techs.yaml'

--- a/tests/resources/national/model.yaml
+++ b/tests/resources/national/model.yaml
@@ -1,6 +1,6 @@
 import:
     - '../../../build/model/interest-rate.yaml'
-    - '../../../build/model/cost-overrides.yaml'
+    - '../../../build/model/tech-costs.yaml'
     - '../../../build/model/renewable-techs.yaml'
     - '../../../build/model/storage-techs.yaml'
     - '../../../build/model/link-techs.yaml'

--- a/tests/resources/national/model.yaml
+++ b/tests/resources/national/model.yaml
@@ -16,7 +16,8 @@ scenarios:
     default: []
     connected: ["connect"]
     directional-pv: ["directional-rooftop-pv"]
-    frozen-hydro: ["freeze-hydro-capacities"]
+    frozen-hydro: ["freeze-hydro-capacities", "no-hydro-fixed-cost"]
+    alternative-cost: ["dea-renewable-cost", "schroeder-hydro-cost"]
 overrides:
     connect:
         import:

--- a/tests/resources/regional/model.yaml
+++ b/tests/resources/regional/model.yaml
@@ -1,5 +1,6 @@
 import:
     - '../../../build/model/interest-rate.yaml'
+    - '../../../build/model/cost-overrides.yaml'
     - '../../../build/model/renewable-techs.yaml'
     - '../../../build/model/storage-techs.yaml'
     - '../../../build/model/link-techs.yaml'

--- a/tests/resources/regional/model.yaml
+++ b/tests/resources/regional/model.yaml
@@ -1,6 +1,6 @@
 import:
     - '../../../build/model/interest-rate.yaml'
-    - '../../../build/model/cost-overrides.yaml'
+    - '../../../build/model/tech-costs.yaml'
     - '../../../build/model/renewable-techs.yaml'
     - '../../../build/model/storage-techs.yaml'
     - '../../../build/model/link-techs.yaml'

--- a/tests/resources/regional/model.yaml
+++ b/tests/resources/regional/model.yaml
@@ -16,7 +16,8 @@ scenarios:
     default: []
     connected: ["connect"]
     directional-pv: ["directional-rooftop-pv"]
-    frozen-hydro: ["freeze-hydro-capacities"]
+    frozen-hydro: ["freeze-hydro-capacities", "no-hydro-fixed-cost"]
+    alternative-cost: ["dea-renewable-cost", "schroeder-hydro-cost"]
 overrides:
     connect:
         import:


### PR DESCRIPTION
Fixes #18  .

Forces user to specify a source for cost assumptions using overrides. Currently, [etri](https://publications.jrc.ec.europa.eu/repository/handle/JRC92496) or [dea](https://ens.dk/en/our-services/projections-and-models/technology-data/technology-data-generation-electricity-and) can be chosen for `renewable-cost` and etri and Schröder et al. ([2013](https://www.econstor.eu/bitstream/10419/80348/1/757528015.pdf)) for `hydro-cost` while more sources can be added in `cost-overrides.yaml`.

Two potential issues:

1. When no override is specified, the model assumes that technologies are free to use
2. There are errors in rule test that I can't quite trace

## Checklist

Any checks which are not relevant to the PR can be pre-checked by the PR creator. All others should be checked by the reviewer. You can add extra checklist items here if required by the PR.

- [x] CHANGELOG updated
- [x] Minimal workflow tests pass
- [x] Tests added to cover contribution
- [x] Documentation updated
- [x] Configuration schema updated
- [x] Review parameter values en detail
