### PR TITLE
Fix moving of hydro stations by transforming to projection first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * **ADD** minimal configuration to be able to test the entire workflow more quickly (#60).
 * **ADD** installation of `curl` and `unzip` from conda-forge, to increase portability (#59).
 * **ADD** sync infrastructure to easily send and receive files to and from a cluster (#74).
+* **ADD** parameter `station-nearest-basin-max-km` controlling the mapping of hydro power stations to basins (#138).
 * **ADD** optional email notifications whenever builds fail or succeed (#92).
 
 * **UPDATE** EEZ updated from v10 to v11 (difference in offshore area is < 1% for all relevant countries) (#99).

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -64,6 +64,7 @@ quality-control:
             - actual_entsoe_power_statistics
     hydro:
         scale-phs-according-to-geth-et-al: false
+        stations-buffer-size-km: 1
 sea-connections:
     continental: []
     national: # Source: https://www.entsoe.eu/data/map/

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -64,7 +64,7 @@ quality-control:
             - actual_entsoe_power_statistics
     hydro:
         scale-phs-according-to-geth-et-al: false
-        stations-buffer-size-km: 1
+        station-nearest-basin-max-km: 1
 sea-connections:
     continental: []
     national: # Source: https://www.entsoe.eu/data/map/

--- a/config/schema.yaml
+++ b/config/schema.yaml
@@ -265,6 +265,9 @@ properties:
                     scale-phs-according-to-geth-et-al:
                         type: boolean
                         description: Whether or not to use pumped hydro capacities derived from Geth et al. (2015) to scale pumped hydro capacities givven by the JRC hydro database.
+                    stations-buffer-size-km:
+                        type: number
+                        description: Move stations outside of hydrobasins into closest basin by max this amount (fails otherwise).
     capacity_factors:
         type: object
         properties:

--- a/config/schema.yaml
+++ b/config/schema.yaml
@@ -265,8 +265,9 @@ properties:
                     scale-phs-according-to-geth-et-al:
                         type: boolean
                         description: Whether or not to use pumped hydro capacities derived from Geth et al. (2015) to scale pumped hydro capacities givven by the JRC hydro database.
-                    stations-buffer-size-km:
+                    station-nearest-basin-max-km:
                         type: number
+                        minimum: 0
                         description: Move stations outside of hydrobasins into closest basin by max this amount (fails otherwise).
     capacity_factors:
         type: object

--- a/lib/eurocalliopelib/geo/__init__.py
+++ b/lib/eurocalliopelib/geo/__init__.py
@@ -1,3 +1,4 @@
 from .spatiotemporal import area_weighted_time_series, convert_old_style_capacity_factor_time_series # noqa: F401
 
+WGS84 = "EPSG:4326"
 EPSG3035 = "EPSG:3035"

--- a/rules/hydro.smk
+++ b/rules/hydro.smk
@@ -86,7 +86,7 @@ rule preprocess_hydro_stations:
         basins = rules.preprocess_basins.output[0],
         phs_storage_capacities = config["data-sources"]["national-phs-storage-capacities"]
     params:
-        buffer_size_m = config["quality-control"]["hydro"]["stations-buffer-size-km"] * 1000,
+        buffer_size_m = config["quality-control"]["hydro"]["station-nearest-basin-max-km"] * 1000,
         countries = config["scope"]["countries"],
         scale_phs = config["quality-control"]["hydro"]["scale-phs-according-to-geth-et-al"]
     output: "build/data/jrc-hydro-power-plant-database-preprocessed.csv"

--- a/rules/hydro.smk
+++ b/rules/hydro.smk
@@ -86,7 +86,7 @@ rule preprocess_hydro_stations:
         basins = rules.preprocess_basins.output[0],
         phs_storage_capacities = config["data-sources"]["national-phs-storage-capacities"]
     params:
-        buffer_size = 1 / 60, # move stations up to 1 arcminute < 1 km
+        buffer_size_m = config["quality-control"]["hydro"]["stations-buffer-size-km"] * 1000,
         countries = config["scope"]["countries"],
         scale_phs = config["quality-control"]["hydro"]["scale-phs-according-to-geth-et-al"]
     output: "build/data/jrc-hydro-power-plant-database-preprocessed.csv"

--- a/scripts/hydro/preprocess_hydro_stations.py
+++ b/scripts/hydro/preprocess_hydro_stations.py
@@ -1,6 +1,5 @@
 import pandas as pd
 import geopandas as gpd
-from shapely.geometry import Point
 import pycountry
 
 from eurocalliopelib import utils
@@ -126,7 +125,7 @@ def station_in_any_basin(basins):
 def ensure_stations_within_basins(stations, path_to_basins, buffer_size_m):
     geo_stations = gpd.GeoDataFrame(
         stations.copy(),
-        geometry=[Point(station["lon"], station["lat"]) for _, station in stations.iterrows()],
+        geometry=gpd.points_from_xy(stations["lon"], stations["lat"]),
         crs=WGS84
     ).to_crs(EPSG3035)
     hydrobasins = gpd.read_file(path_to_basins).to_crs(EPSG3035)
@@ -135,8 +134,8 @@ def ensure_stations_within_basins(stations, path_to_basins, buffer_size_m):
     for station_id, station in ill_placed_stations.iterrows():
         geo_stations.loc[station_id, "geometry"] = new_coords(station, buffer_size_m, hydrobasins)
     assert geo_stations.apply(station_in_any_basin(hydrobasins), axis="columns").all()
-    stations["lon"] = geo_stations.to_crs(WGS84).geometry.apply(lambda point: point.coords[0][0])
-    stations["lat"] = geo_stations.to_crs(WGS84).geometry.apply(lambda point: point.coords[0][1])
+    stations["lon"] = geo_stations.to_crs(WGS84).geometry.x
+    stations["lat"] = geo_stations.to_crs(WGS84).geometry.y
     return stations
 
 


### PR DESCRIPTION
Fixes #55.

This was not exactly broken, but let to warnings by geopandas. Further, the buffer size is now the same for all stations that must be moved and the buffer size is easier to understand.

## Checklist

Any checks which are not relevant to the PR can be pre-checked by the PR creator. All others should be checked by the reviewer. You can add extra checklist items here if required by the PR.

- [x] CHANGELOG updated
- [x] Minimal workflow tests pass
- [x] Tests added to cover contribution
- [x] Documentation updated
- [x] Configuration schema updated
