### PR TITLE
Fix syncignore to ignore data/euro-calliope-datasets

### DIFF
--- a/.syncignore-send
+++ b/.syncignore-send
@@ -8,4 +8,5 @@ __pycache__
 .DS_Store
 build
 data/automatic
+data/euro-calliope-datasets
 notebooks


### PR DESCRIPTION
This tiny bug has been introduced in #112 which implemented #104.

## Checklist

Any checks which are not relevant to the PR can be pre-checked by the PR creator. All others should be checked by the reviewer. You can add extra checklist items here if required by the PR.

- [x] CHANGELOG updated
- [x] Minimal workflow tests pass
- [x] Tests added to cover contribution
- [x] Documentation updated
- [x] Configuration schema updated
