### PR TITLE
Fix directional pv to not use shapes

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -156,14 +156,14 @@ rule directional_rooftop_pv:
     message: "Generate override for directional rooftop PV in {wildcards.resolution} resolution."
     input:
         script = script_dir + "directional_rooftop.py",
-        shapes = rules.units.output[0],
+        units = rules.units_without_shape.output[0],
         land_eligibility_km2 = rules.potentials.output.land_eligibility_km2,
     params:
         roof_shares = config["parameters"]["roof-share"],
         maximum_installable_power_density = config["parameters"]["maximum-installable-power-density"],
         scaling_factors = config["scaling-factors"],
     output: "build/model/{resolution}/directional-rooftop.yaml"
-    conda: "envs/geo.yaml"
+    conda: "envs/default.yaml"
     script: "scripts/directional_rooftop.py"
 
 

--- a/scripts/directional_rooftop.py
+++ b/scripts/directional_rooftop.py
@@ -1,7 +1,6 @@
 """Creates Calliope location files."""
 import jinja2
 import pandas as pd
-import geopandas as gpd
 
 from eurocalliopelib import filters
 
@@ -48,13 +47,11 @@ TEMPLATE = """overrides:
 """
 
 
-def directional_rooftop(path_to_shapes, path_to_land_eligibility_km2,
+def directional_rooftop(path_to_units, path_to_land_eligibility_km2,
                         roof_shares, maximum_installable_power_density,
                         scaling_factors, path_to_result):
     """Generate a file that represents locations in Calliope."""
-    locations = gpd.GeoDataFrame(
-        gpd.read_file(path_to_shapes).set_index("id").centroid.rename("centroid")
-    )
+    locations = pd.read_csv(path_to_units, index_col=0)
     capacities = _from_area_to_installed_capacity(
         land_eligibiligy_km2=pd.read_csv(path_to_land_eligibility_km2, index_col=0),
         roof_shares=roof_shares,
@@ -104,7 +101,7 @@ def _from_area_to_installed_capacity(land_eligibiligy_km2, roof_shares,
 
 if __name__ == "__main__":
     directional_rooftop(
-        path_to_shapes=snakemake.input.shapes,
+        path_to_units=snakemake.input.units,
         path_to_land_eligibility_km2=snakemake.input.land_eligibility_km2,
         path_to_result=snakemake.output[0],
         roof_shares=snakemake.params["roof_shares"],


### PR DESCRIPTION
This resolves a GeoPandas warning about centroid determination which in fact was not necessary in the first place. Also, it allows to directional-pv to be derived from within the default env, not the geo env.

## Checklist

Any checks which are not relevant to the PR can be pre-checked by the PR creator. All others should be checked by the reviewer. You can add extra checklist items here if required by the PR.

- [x] CHANGELOG updated
- [x] Minimal workflow tests pass
- [x] Tests added to cover contribution
- [x] Documentation updated
- [x] Configuration schema updated
