### PR TITLE
Generalise unit conversion function

### DIFF
--- a/lib/eurocalliopelib/utils.py
+++ b/lib/eurocalliopelib/utils.py
@@ -79,13 +79,15 @@ def convert_unit(df, output_unit, input_unit=None, unit_in_output_idx=True):
             raise ValueError("Cannot infer unit for data")
         else:
             mask = df.index
-    df.loc[mask] *= UNIT_CONVERSION_MAPPING[(input_unit.lower(), output_unit.lower())]
+
+    if input_unit.lower() != output_unit.lower():
+        df.loc[mask] *= UNIT_CONVERSION_MAPPING[(input_unit.lower(), output_unit.lower())]
 
     if units is None and unit_in_output_idx is True:
-        df = add_idx_level(df, unit=output_unit)
+        df = add_idx_level(df, unit=output_unit.lower())
     elif units is not None:
         if unit_in_output_idx is True:
-            idx_renamer = lambda x: output_unit if x == input_unit else x
+            idx_renamer = lambda x: output_unit.lower() if x == input_unit else x
             df = df.rename(idx_renamer, level="unit")
         else:
             assert len(units) == 1, f"Cannot drop the index level `unit` with multiple units {units}"

--- a/lib/eurocalliopelib/utils.py
+++ b/lib/eurocalliopelib/utils.py
@@ -90,7 +90,9 @@ def convert_unit(df, output_unit, input_unit=None, unit_in_output_idx=True):
         If `unit_in_output_idx` is False, there will be no index level `unit` in `df`.
     """
     df = df.copy()
+    low_output_unit = output_unit.lower()
     if isinstance(df.index, pd.MultiIndex) and "unit" in df.index.names:
+        df = df.rename(lambda x: x.lower(), level="unit")
         units = df.index.get_level_values("unit").unique()
         if input_unit is None:
             assert len(units) == 1, f"Cannot infer unit for data with multiple available units {units}"
@@ -103,7 +105,6 @@ def convert_unit(df, output_unit, input_unit=None, unit_in_output_idx=True):
         else:
             mask = df.index
     low_input_unit = input_unit.lower()
-    low_output_unit = output_unit.lower()
     if low_input_unit != low_output_unit:
         df.loc[mask] *= UNIT_CONVERSION_MAPPING[(low_input_unit, low_output_unit)]
 
@@ -111,11 +112,11 @@ def convert_unit(df, output_unit, input_unit=None, unit_in_output_idx=True):
         df = add_idx_level(df, unit=low_output_unit)
     elif units is not None:
         if unit_in_output_idx is True:
-            idx_renamer = lambda x: low_output_unit if x.lower() == low_input_unit else x
+            idx_renamer = lambda x: low_output_unit if x == low_input_unit else x
             df = df.rename(idx_renamer, level="unit")
         else:
             assert len(units) == 1, f"Cannot drop the index level `unit` with multiple units {units}"
-            df = df.xs(input_unit, level="unit")
+            df = df.xs(low_input_unit, level="unit")
     return df
 
 

--- a/scripts/jrc-idees/industry.py
+++ b/scripts/jrc-idees/industry.py
@@ -53,8 +53,7 @@ def process_energy(data_filepaths, threads):
         names=['energy'],
         keys=['consumption', 'demand']
     )
-    processed_data = processed_data.apply(utils.ktoe_to_twh)
-    processed_data.index = processed_data.index.set_levels(['twh'], level='unit')
+    processed_data = utils.convert_unit(processed_data, output_unit="twh")
 
     return processed_data
 

--- a/scripts/jrc-idees/tertiary.py
+++ b/scripts/jrc-idees/tertiary.py
@@ -35,8 +35,7 @@ CARRIER_NAMES = {
 def process_jrc_tertiary_data(data_dir, out_path):
     data_filepaths = list(Path(data_dir).glob("*.xlsx"))
     processed_data = pd.concat([get_tertiary_sector_data(file) for file in data_filepaths])
-    processed_data = processed_data.apply(utils.ktoe_to_twh)
-    processed_data.index = processed_data.index.set_levels(['twh'], level='unit')
+    processed_data = utils.convert_unit(processed_data, output_unit="twh")
     processed_data.to_csv(out_path)
 
 

--- a/scripts/jrc-idees/transport.py
+++ b/scripts/jrc-idees/transport.py
@@ -64,8 +64,7 @@ def process_jrc_transport_data(data_dir, dataset, out_path):
         for file in data_filepaths
     ])
     if DATASET_PARAMS[dataset]["unit"] == "ktoe":
-        processed_data = processed_data.apply(utils.ktoe_to_twh)
-        processed_data.index = processed_data.index.set_levels(['twh'], level='unit')
+        processed_data = utils.convert_unit(processed_data, output_unit="twh")
 
     processed_data.stack('year').to_csv(out_path)
 

--- a/tests/lib/test_utils.py
+++ b/tests/lib/test_utils.py
@@ -179,10 +179,10 @@ class TestConvertUnit:
 
         pd.testing.assert_frame_equal(df_converted.droplevel("unit"), df * conversion_val)
 
-    @pytest.mark.parametrize(("unit_in", "unit_out"), [("TJ", "TWh"), ("TJ", "twh"), ("tj", "TWh")])
+    @pytest.mark.parametrize(("unit_in", "unit_out"), [(["TJ"], "TWh"), (["TJ"], "twh"), (["tj"], "TWh"), (["tj", "TJ"], "twh")])
     def test_upper_lower(self, unit_in, unit_out, create_df):
-        df = create_df([unit_in])
-        df_converted = convert_unit(df, unit_out, unit_in, unit_in_output_idx=True)
+        df = create_df(unit_in)
+        df_converted = convert_unit(df, unit_out, unit_in_output_idx=True)
         assert df_converted.index.get_level_values("unit").difference([unit_out.lower()]).empty
 
     @pytest.mark.parametrize("index_type", ["multi", "single"])


### PR DESCRIPTION
In adding new features, I've come across the need to convert between units of energy on multiple occasions. Before the 'from' and 'to' units had to be explicitly defined, as well as the 'unit' index level added/updated manually. This rolls it all into a tested function.

## Checklist

Any checks which are not relevant to the PR can be pre-checked by the PR creator. All others should be checked by the reviewer. You can add extra checklist items here if required by the PR.

- [ ] CHANGELOG updated
- [ ] Minimal workflow tests pass
- [ ] Tests added to cover contribution
- [ ] Documentation updated
- [ ] Configuration schema updated
