### PR TITLE
Update dataset download to prepare for release

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,10 +1,6 @@
 # For descriptions of the configuration values, see `./schema.yaml`.
 data-sources:
-    biofuel-potentials: data/euro-calliope-datasets/biofuels/potentials/{feedstock}.csv
-    biofuel-costs: data/euro-calliope-datasets/biofuels/costs/{feedstock}.csv
     eez: https://geo.vliz.be/geoserver/MarineRegions/wfs?service=WFS&version=1.0.0&request=GetFeature&typeNames=MarineRegions:eez&outputFormat=SHAPE-ZIP
-    irena-generation: data/euro-calliope-datasets/irena/hydro-generation-europe.csv
-    national-phs-storage-capacities: data/euro-calliope-datasets/pumped-hydro/storage-capacities-gwh.csv
     capacity-factors: https://zenodo.org/record/3899687/files/{filename}?download=1
     gadm: https://biogeo.ucdavis.edu/data/gadm3.6/gpkg/gadm36_{country_code}_gpkg.zip
     hydro-basins: https://www.dropbox.com/sh/hmpwobbz9qixxpe/AADeU9iCgMd3ZO1KgrFmfWu6a/HydroBASINS/standard/eu/hybas_eu_lev07_v1c.zip?dl=1
@@ -12,7 +8,7 @@ data-sources:
     load: https://data.open-power-system-data.org/time_series/2019-06-05/time_series_60min_stacked.csv
     nuts: https://ec.europa.eu/eurostat/cache/GISCO/geodatafiles/NUTS_2013_01M_SH.zip
     potentials: https://zenodo.org/record/5112963/files/possibility-for-electricity-autarky.zip
-    data-repository: https://raw.githubusercontent.com/calliope-project/euro-calliope-datasets/develop/{dataset}
+    data-repository: https://github.com/calliope-project/euro-calliope-datasets/archive/refs/heads/develop.zip
     entsoe-tyndp: https://2020.entsos-tyndp-scenarios.eu/wp-content/uploads/2020/06/TYNDP-2020-Scenario-Datafile.xlsx.zip
 root-directory: .
 cluster-sync:

--- a/config/schema.yaml
+++ b/config/schema.yaml
@@ -10,25 +10,9 @@ properties:
         type: object
         description: Paths and URLs to datasets.
         properties:
-            biofuel-potentials:
-                type: string
-                pattern: .*{feedstock}.*\.csv$
-                description: Path to local biofuel potentials. Must contain {feedstock} placeholder.
-            biofuel-costs:
-                type: string
-                pattern: .*{feedstock}.*\.csv$
-                description: Path to local cost data. Must contain {feedstock} placeholder.
             eez:
                 type: string
                 description: Path to local geospatial Exclusive Economic Zones data.
-            irena-generation:
-                type: string
-                pattern: .*\.csv$
-                description: Path to local hydro generation data from IRENA.
-            national-phs-storage-capacities:
-                type: string
-                pattern: .*\.csv$
-                description: Path to local storage capacities data (in GWh).
             capacity-factors:
                 type: string
                 pattern: ^(https?|http?):\/\/.+{filename}.*
@@ -59,7 +43,7 @@ properties:
                 description: Web address of potentials of solar and wind.
             data-repository:
                 type: string
-                pattern: ^(https?|http?):\/\/.+{dataset}.*
+                pattern: ^(https?|http?):\/\/.+
                 description: Web address of proprietry datasets that have been pre-processed for specific use in Euro-Calliope.
     root-directory:
         type: string

--- a/envs/shell.yaml
+++ b/envs/shell.yaml
@@ -5,3 +5,4 @@ dependencies:
     - curl=7.76.0
     - unzip=6.0
     - rsync=3.2.3
+    - tar=1.34

--- a/rules/data.smk
+++ b/rules/data.smk
@@ -1,0 +1,49 @@
+"""Rules that access raw data."""
+
+BIOFUEL_FEEDSTOCKS = [
+    "forestry-energy-residues",
+    "landscape-care-residues",
+    "manure",
+    "municipal-waste",
+    "primary-agricultural-residues",
+    "roundwood-chips",
+    "roundwood-fuelwood",
+    "secondary-forestry-residues-sawdust",
+    "secondary-forestry-residues-woodchips",
+    "sludge"
+]
+localrules: download_euro_calliope_datasets, euro_calliope_datasets
+
+
+rule download_euro_calliope_datasets:
+    message: "Download Euro-Calliope datasets."
+    params: url = config["data-sources"]["data-repository"]
+    output: protected("data/automatic/euro-calliope-datasets.zip")
+    conda: "../envs/shell.yaml"
+    shell: "curl -sLfo {output} {params.url}"
+
+
+rule euro_calliope_datasets:
+    message: "Unzip Euro-Calliope datasets."
+    input: rules.download_euro_calliope_datasets.output[0]
+    shadow: "minimal"
+    output:
+        irena_generation = "build/data/irena/hydro-generation-europe.csv",
+        national_phs_storage_capacities = "build/data/pumped-hydro/storage-capacities-gwh.csv",
+        biofuel_potentials = expand(
+            "build/data/biofuels/potentials/{feedstock}.csv",
+            feedstock=BIOFUEL_FEEDSTOCKS),
+        biofuel_costs = expand(
+            "build/data/biofuels/costs/{feedstock}.csv",
+            feedstock=BIOFUEL_FEEDSTOCKS)
+    conda: "../envs/shell.yaml"
+    shell:
+        # This script removes the top-level directory, whose name we do not know.
+        # Because tar can do this but unzip can not, we unzip first, then tar again,
+        # and finally untar while removing the top-level.
+        """
+        mkdir build/tmp/
+        unzip -o {input} -d build/tmp
+        tar cf build/tmp.tar --directory build/tmp/ .
+        tar xf build/tmp.tar --directory build/data --strip-components=2
+        """

--- a/rules/hydro.smk
+++ b/rules/hydro.smk
@@ -84,7 +84,7 @@ rule preprocess_hydro_stations:
         script = script_dir + "hydro/preprocess_hydro_stations.py",
         stations = rules.stations_database.output[0],
         basins = rules.preprocess_basins.output[0],
-        phs_storage_capacities = config["data-sources"]["national-phs-storage-capacities"]
+        phs_storage_capacities = rules.euro_calliope_datasets.output.national_phs_storage_capacities
     params:
         buffer_size_m = config["quality-control"]["hydro"]["station-nearest-basin-max-km"] * 1000,
         countries = config["scope"]["countries"],
@@ -112,7 +112,7 @@ rule inflow_mwh:
     input:
         script = script_dir + "hydro/inflow_mwh.py",
         stations = rules.inflow_m3.output[0],
-        generation = config["data-sources"]["irena-generation"]
+        generation = rules.euro_calliope_datasets.output.irena_generation
     params:
         year = config["year"],
         max_capacity_factor = config["capacity-factors"]["max"]


### PR DESCRIPTION
This prepares for the release of 1.1. Before we can release euro-calliope 1.1, we need to release euro-calliope-datasets 1.1. For consistency, we should release on Zenodo. Zenodo does not support folders of files, unfortunately. The only way to retain folders is to upload everything as a zip-archive. So far, the download in euro-calliope expected to be able to download single files. This will not be possible anymore. Therefore, here's a change to prepare for that.

I know that the new `data.smk` is slightly arbitrary. I needed a new file though (so that the download rules are defined before other rules try to access these rules) and I wanted to introduce a minimal change. We really need to rethink the Snakefile structure, but I did not want to do this in this change -- just before release.

## Checklist

Any checks which are not relevant to the PR can be pre-checked by the PR creator. All others should be checked by the reviewer. You can add extra checklist items here if required by the PR.

- [ ] CHANGELOG updated
- [ ] Minimal workflow tests pass
- [ ] Tests added to cover contribution
- [ ] Documentation updated
- [ ] Configuration schema updated
