### PR TITLE
Update retrieval of euro-calliope-datasets

### DIFF
--- a/.syncignore-send
+++ b/.syncignore-send
@@ -8,5 +8,4 @@ __pycache__
 .DS_Store
 build
 data/automatic
-data/euro-calliope-datasets
 notebooks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
     1. Romanian PHS data is no longer manually added from Geth et al. (2015).
 * **UPDATE** JRC biofuel potentials data source from @RuizCastello:2015 to ENSPRESO (@Ruiz:2019) (#194). This changes the potentials of the continent (0.1% less), Montenegro (93% less), North Macedonia (44% less), the UK (6% more), and the Netherlands (1% less).
 * **UPDATE** Improve gap-filling method for national electricity load data (#3).
+* **UPDATE** location of non-automatically derivable datasets: they are  not included in the workflow repository anymore, but instead published separately on Zenodo (#201).
 * **UPDATE** dependencies (#44, #73, #142):
     * Python 3.7 -> 3.8
     * Snakemake 5.8.2 -> 6.1.1 (uses mamba by default)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,25 +105,23 @@ Take the existing fixtures as a starting point.
 Whenever you want to publish a new release of Euro-Calliope, you need to perform several manual steps.
 Be aware that you can publish a release only if you are a maintainer of the two central GitHub repositories and if you have edit access to the three Zenodo archives linked below.
 
-1. Release upstream repo [`euro-calliope-datasets`](https://github.com/calliope-project/euro-calliope-datasets) (using the same version number `vX.Y.Z`) and publish on Zenodo.
-2. Branch off of `develop` into a `release-vX.Y.Z` branch and apply the following changes:
-    1. Link to Zenodo release of `euro-calliope-datasets` in the `data-sources.data-repository` config parameter in [./config/default.yaml](./config/default.yaml).
-    2. Bump version to `vX.Y.Z` in the following places:
+1. Branch off of `develop` into a `release-vX.Y.Z` branch and apply the following changes:
+    1. Bump version to `vX.Y.Z` in the following places:
         * [./CITATION.cff](./CITATION.cff)
         * [./VERSION](./VERSION)
         * [.github/ISSUE_TEMPLATE/BUG-REPORT.yml](.github/ISSUE_TEMPLATE/BUG-REPORT.yml)
         * [.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml](.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml)
         * [./lib/setup.py](./lib/setup.py)
         * [./lib/eurocalliopelib/__init__.py](./lib/eurocalliopelib/__init__.py)
-    3. Verify consistent versions of Snakemake and Calliope.
+    2. Verify consistent versions of Snakemake and Calliope.
     Their versions are spread over the entire repository (including urls in the documentation).
     Use search and replace to make sure all versions are consistent.
-    4. Update the changelog and add the release date.
-    5. Update [./LICENSE.md](./LICENSE.md) if necessary.
+    3. Update the changelog and add the release date.
+    4. Update [./LICENSE.md](./LICENSE.md) if necessary.
     5. (If necessary) Update `docs/img/spatial-scope-and-resolutions.png` by running `snakemake -j1 --use-conda -s rules/doc.smk docs/img/spatial-scope-and-resolutions.png`. Inspect the result visually. Check it in if it changed; check out the old version if it did not change. The figure will change when the spatial scope or resolution has changed.
-3. Build the pre-builts and test everything using the `all_tests` rule.
-4. Commit, open a pull request onto `develop`, and merge the release branch into both `develop` and `main` after successful review.
-5. Add a `vX.Y.Z` release tag to `main`.
-6. Bump version on `develop` in the same places as in point 2.
-7. Upload the pre-builts to [their home on Zenodo](https://doi.org/10.5281/zenodo.3949552).
-8. Download the release version of the workflow code from GitHub and upload to [its home on Zenodo](https://doi.org/10.5281/zenodo.3949793).
+2. Build the pre-builts and test everything using the `all_tests` rule.
+3. Commit, open a pull request onto `develop`, and merge the release branch into both `develop` and `main` after successful review.
+4. Add a `vX.Y.Z` release tag to `main`.
+5. Bump version on `develop` in the same places as in point 2.
+6. Upload the pre-builts to [their home on Zenodo](https://doi.org/10.5281/zenodo.3949552).
+7. Download the release version of the workflow code from GitHub and upload to [its home on Zenodo](https://doi.org/10.5281/zenodo.3949793).

--- a/Snakefile
+++ b/Snakefile
@@ -16,8 +16,8 @@ include: "./rules/wind-and-solar.smk"
 include: "./rules/biofuels.smk"
 include: "./rules/hydro.smk"
 include: "./rules/sync.smk"
-localrules: all, download_raw_load, model, clean, parameterise_template, download_potentials, download_eurocalliope_dataset
-localrules: download_capacity_factors_wind_and_solar, download_entsoe_tyndp_zip
+localrules: all, download_raw_load, model, clean, parameterise_template
+localrules: download_entsoe_tyndp_zip
 wildcard_constraints:
         resolution = "continental|national|regional"
 
@@ -290,7 +290,7 @@ rule clean: # removes all generated results
     shell:
         """
         rm -r build/
-        echo "Data downloaded to data/automatic/ and data/euro-calliope-datasets has not been cleaned."
+        echo "Data downloaded to data/automatic/ has not been cleaned."
         """
 
 
@@ -311,11 +311,3 @@ rule test:
     output: "build/logs/{resolution}/test-report.html"
     conda: "./envs/test.yaml"
     script: "./tests/model/test_runner.py"
-
-
-rule download_eurocalliope_dataset:
-    message: "Downloading `{wildcards.dataset}` from Euro-Calliope dataset submodule"
-    params: url = lambda wildcards: config["data-sources"]["data-repository"].format(dataset=wildcards.dataset)
-    output: "data/euro-calliope-datasets/{dataset}"
-    conda: "envs/shell.yaml"
-    shell: "curl -sLfo {output} {params.url}"

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -2,8 +2,8 @@
 data-sources:
     biofuel-potentials-and-costs: https://cidportal.jrc.ec.europa.eu/ftp/jrc-opendata/ENSPRESO/ENSPRESO_BIOMASS.xlsx
     eez: https://geo.vliz.be/geoserver/MarineRegions/wfs?service=WFS&version=1.0.0&request=GetFeature&typeNames=MarineRegions:eez&outputFormat=SHAPE-ZIP
-    irena-generation: data/euro-calliope-datasets/irena/hydro-generation-europe.csv
-    national-phs-storage-capacities: data/euro-calliope-datasets/pumped-hydro/storage-capacities-gwh.csv
+    hydro-generation: https://zenodo.org/record/5797549/files/hydro-generation.csv?download=1
+    national-phs-storage-capacities: https://zenodo.org/record/5797549/files/pumped-hydro-storage-capacities-gwh.csv?download=1
     capacity-factors: https://zenodo.org/record/3899687/files/{filename}?download=1
     gadm: https://biogeo.ucdavis.edu/data/gadm3.6/gpkg/gadm36_{country_code}_gpkg.zip
     hydro-basins: https://www.dropbox.com/sh/hmpwobbz9qixxpe/AADeU9iCgMd3ZO1KgrFmfWu6a/HydroBASINS/standard/eu/hybas_eu_lev07_v1c.zip?dl=1
@@ -11,7 +11,6 @@ data-sources:
     load: https://data.open-power-system-data.org/time_series/2019-06-05/time_series_60min_stacked.csv
     nuts: https://ec.europa.eu/eurostat/cache/GISCO/geodatafiles/NUTS_2013_01M_SH.zip
     potentials: https://zenodo.org/record/5112963/files/possibility-for-electricity-autarky.zip
-    data-repository: https://raw.githubusercontent.com/calliope-project/euro-calliope-datasets/develop/{dataset}
     entsoe-tyndp: https://2020.entsos-tyndp-scenarios.eu/wp-content/uploads/2020/06/TYNDP-2020-Scenario-Datafile.xlsx.zip
 root-directory: .
 cluster-sync:

--- a/config/schema.yaml
+++ b/config/schema.yaml
@@ -33,14 +33,14 @@ properties:
             eez:
                 type: string
                 description: Path to local geospatial Exclusive Economic Zones data.
-            irena-generation:
+            hydro-generation:
                 type: string
-                pattern: .*\.csv$
-                description: Path to local hydro generation data from IRENA.
+                pattern: ^(https?|http?):\/\/.+
+                description: Web address of hydro generation data.
             national-phs-storage-capacities:
                 type: string
-                pattern: .*\.csv$
-                description: Path to local storage capacities data (in GWh).
+                pattern: ^(https?|http?):\/\/.+
+                description: Web address of storage capacities data (in GWh).
             capacity-factors:
                 type: string
                 pattern: ^(https?|http?):\/\/.+{filename}.*
@@ -69,10 +69,6 @@ properties:
                 type: string
                 pattern: ^(https?|http?):\/\/.+
                 description: Web address of potentials of solar and wind.
-            data-repository:
-                type: string
-                pattern: ^(https?|http?):\/\/.+{dataset}.*
-                description: Web address of proprietry datasets that have been pre-processed for specific use in Euro-Calliope.
     root-directory:
         type: string
         description: Path to the root directory of euro-calliope containing scripts and template folders.

--- a/docs/workflow/overview.md
+++ b/docs/workflow/overview.md
@@ -50,7 +50,6 @@ When you have downloaded or cloned the workflow, you will have a set of files in
 * `build/model`: Contains the entire model after the build step, including Calliope definition files and data (does not exist initially).
 * `config`: Files with configuration parameters that customise the model build process.
 * `data/automatic`: Contains data automatically downloaded from third-party sources within the model build process (does not exist initially).
-* `data/euro-calliope-dataset`: Contains data automatically downloaded from the [Euro-Calliope datasets repository](https://github.com/calliope-project/euro-calliope-datasets) within the model build process (does not exist initially).
 * `docs`: Documentation of the model and the build process.
 * `envs`: Files defining the conda environments that are used to build the model.
 * `lib`: Library code in form of a Python package that is reused in many places of this repository.

--- a/rules/hydro.smk
+++ b/rules/hydro.smk
@@ -1,9 +1,29 @@
 """Rules to generate hydro electricity capacities and time series."""
 
 localrules: download_runoff_data, download_basins_database, download_stations_database
-localrules: basins_database, stations_database
+localrules: download_generation_data, basins_database, stations_database
 root_dir = config["root-directory"] + "/" if config["root-directory"] not in ["", "."] else ""
 script_dir = f"{root_dir}scripts/"
+
+
+rule download_hydro_generation_data:
+    message: "Download database of historical hydro power generation."
+    params: url = config["data-sources"]["hydro-generation"]
+    output:
+        protected("data/automatic/raw-hydro-generation.csv")
+    conda: "../envs/shell.yaml"
+    shell:
+        "curl -sLo {output} '{params.url}'"
+
+
+rule download_pumped_hydro_data:
+    message: "Download database of pumped hydro storage capacity data."
+    params: url = config["data-sources"]["national-phs-storage-capacities"]
+    output:
+        protected("data/automatic/raw-pumped-hydro-storage-capacities-gwh.csv")
+    conda: "../envs/shell.yaml"
+    shell:
+        "curl -sLo {output} '{params.url}'"
 
 
 rule download_runoff_data:
@@ -83,7 +103,7 @@ rule preprocess_hydro_stations:
         script = script_dir + "hydro/preprocess_hydro_stations.py",
         stations = rules.stations_database.output[0],
         basins = rules.preprocess_basins.output[0],
-        phs_storage_capacities = config["data-sources"]["national-phs-storage-capacities"]
+        phs_storage_capacities = rules.download_pumped_hydro_data.output[0]
     params:
         buffer_size_m = config["quality-control"]["hydro"]["station-nearest-basin-max-km"] * 1000,
         countries = config["scope"]["countries"],
@@ -111,7 +131,7 @@ rule inflow_mwh:
     input:
         script = script_dir + "hydro/inflow_mwh.py",
         stations = rules.inflow_m3.output[0],
-        generation = config["data-sources"]["irena-generation"]
+        generation = rules.download_hydro_generation_data.output[0]
     params:
         year = config["year"],
         max_capacity_factor = config["capacity-factors"]["max"]


### PR DESCRIPTION
euro-calliope-datasets are now retrieved from Zenodo only. This has three advantages:

* We need to maintain the Zenodo repo only -- we can abandon the GitHub repo.
* We can download each dataset separately.
* We can (if needed) download datasets from different versions on Zenodo and therefore we can be more flexible with versioning.

All together should reduce complexity and make the development and all releases easier.

## Checklist

Any checks which are not relevant to the PR can be pre-checked by the PR creator. All others should be checked by the reviewer. You can add extra checklist items here if required by the PR.

- [x] CHANGELOG updated
- [x] Minimal workflow tests pass
- [x] Tests added to cover contribution
- [x] Documentation updated
- [x] Configuration schema updated
