### PR TITLE
Fix jinja2 and mkdocs compatibility

### DIFF
--- a/envs/docs.yaml
+++ b/envs/docs.yaml
@@ -5,7 +5,7 @@ channels:
 dependencies:
     - Python=3.8
     - mkdocs=1.2.2
-    - jinja=3.0.3
+    - jinja2=3.0.3
     - graphviz=2.48.0
     - pydot=1.4.2
     - pycountry=18.12.8

--- a/envs/docs.yaml
+++ b/envs/docs.yaml
@@ -5,6 +5,7 @@ channels:
 dependencies:
     - Python=3.8
     - mkdocs=1.2.2
+    - jinja=3.0.3
     - graphviz=2.48.0
     - pydot=1.4.2
     - pycountry=18.12.8


### PR DESCRIPTION
jinja2 3.1.0 breaks mkdocs (https://github.com/mkdocs/mkdocs/issues/2799), therefore fix jinja2 version to <3.1.0.

## Checklist

Any checks which are not relevant to the PR can be pre-checked by the PR creator. All others should be checked by the reviewer. You can add extra checklist items here if required by the PR.

- [x] CHANGELOG updated
- [x] Minimal workflow tests pass
- [x] Tests added to cover contribution
- [x] Documentation updated
- [x] Configuration schema updated
