### PR TITLE
Fix incompatibility of Snakemake 6.1.1. and tabulate 0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@
 
 * **FIX** links in the documention to always point to the most recent version of the pre-builts (#218).
 
+### Fixed (environments)
+
+* **FIX** incompatibility of Snakemake 6.1.1 and tabulate 0.9 by downgrading to tabulate 0.8.10. (#249).
+
 ## 1.1.0 (2021-12-22)
 
 This version is a minor update to v1.0. It comes with updated input data, updated dependencies, several convenience features, several optional overrides, and with massively extended documentation. You should not expect model results to deviate much from v1.0.

--- a/environment.yaml
+++ b/environment.yaml
@@ -6,3 +6,4 @@ dependencies:
     - python=3.8
     - pycountry=18.12.8
     - snakemake-minimal=6.1.1
+    - tabulate=0.8.10 # fixes incompatibility of tabulate 0.9 and snakemake 6.1.1. Should be fixed after snakemake 7.15.2


### PR DESCRIPTION
Fixes #247 .

Fix incompatibility of Snakemake 6.1.1. and tabulate 0.9 by downgrading to tabulate 0.8.10 in environment.yaml file.
This bug should be fixed in newer versions of Snakemake starting at 7.15.2.

## Checklist

Any checks which are not relevant to the PR can be pre-checked by the PR creator. All others should be checked by the reviewer. You can add extra checklist items here if required by the PR.

- [x] CHANGELOG updated
- [x] Minimal workflow tests pass
- [x] Tests added to cover contribution
- [x] Documentation updated
- [x] Configuration schema updated
