### PR TITLE
Remove unused data from annual transport demand calculations

### DIFF
--- a/rules/transport.smk
+++ b/rules/transport.smk
@@ -7,16 +7,13 @@ rule annual_transport_demand:
         energy_balances = "build/data/annual-energy-balances.csv",
         jrc_road_energy = "build/data/jrc-idees/transport/processed-road-energy.csv",
         jrc_road_distance = "build/data/jrc-idees/transport/processed-road-distance.csv",
-        jrc_road_vehicles = "build/data/jrc-idees/transport/processed-road-vehicles.csv",
     params:
         fill_missing_values = config["parameters"]["transport"]["fill-missing-values"],
         efficiency_quantile = config["parameters"]["transport"]["future-vehicle-efficiency-percentile"]
     conda: "../envs/default.yaml"
     output:
         distance = "build/data/transport/annual-road-transport-distance-demand.csv",
-        vehicles = "build/data/transport/annual-road-transport-vehicles.csv",
-        efficiency = "build/data/transport/annual-road-transport-efficiency.csv",
-        road_electricity_historic = "build/data/transport/annual-road-transport-historic-electrification.csv",
+        distance_historic_electrification = "build/data/transport/annual-road-transport-historic-electrification.csv",
     script: "../scripts/transport/annual_transport_demand.py"
 
 


### PR DESCRIPTION
In the rule annual_transport_demand three variables where calculated: distance, vehicles, and efficiency. We do not need the latter two. In addition, there seemed to be a problem with the calculation of vehicles. In fact, it was equal to distance. See: https://github.com/calliope-project/sector-coupled-euro-calliope/blob/4eeff47ec3b285e0280a4131f6c381cd9028cf75/src/construct/annual_transport_demand.py#L204

I now removed vehicles and efficiency where unneeded.

## Checklist

Any checks which are not relevant to the PR can be pre-checked by the PR creator. All others should be checked by the reviewer. You can add extra checklist items here if required by the PR.

- [x] CHANGELOG updated
- [x] Minimal workflow tests pass
- [x] Tests added to cover contribution
- [x] Documentation updated
- [x] Configuration schema updated
