### PR TITLE
Fix error messages of curl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@ In the following, we split additions, fixes, and updates between those which aff
 * **ADD** ability to move working directory (#45).
 * **ADD** schema that automatically validates configuration files (#45).
 * **ADD** minimal configuration to be able to test the entire workflow more quickly (#60).
-* **ADD** installation of `curl` and `unzip` from conda-forge, to increase portability (#59).
+* **ADD** installation of `curl` and `unzip` from conda-forge, to increase portability (#59, #267).
 * **ADD** sync infrastructure to easily send and receive files to and from a cluster (#74).
 * **ADD** parameter `station-nearest-basin-max-km` controlling the mapping of hydro power stations to basins (#138).
 * **ADD** optional email notifications whenever builds fail or succeed (#92).

--- a/rules/biofuels.smk
+++ b/rules/biofuels.smk
@@ -8,7 +8,7 @@ rule download_biofuel_potentials_and_costs:
     params: url = config["data-sources"]["biofuel-potentials-and-costs"]
     output: protected("data/automatic/raw-biofuel-potentials-and-costs.xlsx")
     conda: "../envs/shell.yaml"
-    shell: "curl -sLo {output} '{params.url}'"
+    shell: "curl -sSLo {output} '{params.url}'"
 
 
 rule preprocess_biofuel_potentials_and_cost:

--- a/rules/data.smk
+++ b/rules/data.smk
@@ -12,7 +12,7 @@ rule download_ch_energy_data:
     wildcard_constraints:
         dataset = "energy-balance|industry-energy-balance|end-use"
     localrule: True
-    shell: "curl -sLo {output} {params.url}"
+    shell: "curl -sSLo {output} {params.url}"
 
 
 "Rules regarding Eurostat Data:"
@@ -27,7 +27,7 @@ rule download_eurostat_energy_data:
     conda: "../envs/shell.yaml"
     output: protected("data/automatic/eurostat-{dataset}.tsv.gz")
     localrule: True
-    shell: "curl -sLo {output} {params.url}"
+    shell: "curl -sSLo {output} {params.url}"
 
 
 rule annual_energy_balances:
@@ -54,7 +54,7 @@ rule download_jrc_idees_zipped:
     output: protected("data/automatic/jrc-idees/{country_code}.zip")
     conda: "../envs/shell.yaml"
     localrule: True
-    shell: "curl -sLo {output} '{params.url}'"
+    shell: "curl -sSLo {output} '{params.url}'"
 
 
 def jrc_to_euro_calliope_sector(sector: str):

--- a/rules/hydro.smk
+++ b/rules/hydro.smk
@@ -11,7 +11,7 @@ rule download_hydro_generation_data:
         protected("data/automatic/raw-hydro-generation.csv")
     conda: "../envs/shell.yaml"
     shell:
-        "curl -sLo {output} '{params.url}'"
+        "curl -sSLo {output} '{params.url}'"
 
 
 rule download_pumped_hydro_data:
@@ -21,7 +21,7 @@ rule download_pumped_hydro_data:
         protected("data/automatic/raw-pumped-hydro-storage-capacities-gwh.csv")
     conda: "../envs/shell.yaml"
     shell:
-        "curl -sLo {output} '{params.url}'"
+        "curl -sSLo {output} '{params.url}'"
 
 
 rule download_runoff_data:
@@ -47,7 +47,7 @@ rule download_basins_database:
         protected("data/automatic/raw-hydro-basins.zip")
     conda: "../envs/shell.yaml"
     shell:
-        "curl -sLo {output} '{params.url}'"
+        "curl -sSLo {output} '{params.url}'"
 
 
 rule download_stations_database:
@@ -57,7 +57,7 @@ rule download_stations_database:
         protected("data/automatic/raw-hydro-stations.zip")
     conda: "../envs/shell.yaml"
     shell:
-        "curl -sLo {output} '{params.url}'"
+        "curl -sSLo {output} '{params.url}'"
 
 
 rule basins_database:

--- a/rules/nuclear.smk
+++ b/rules/nuclear.smk
@@ -5,7 +5,7 @@ rule jrc_power_plant_database_zipped:
     params: url = config["data-sources"]["jrc-ppdb"]
     output:  "data/automatic/jrc_power_plant_database.zip"
     conda: "../envs/shell.yaml"
-    shell: "curl -sLo {output[0]} '{params.url}'"
+    shell: "curl -sSLo {output[0]} '{params.url}'"
 
 
 rule jrc_power_plant_database:

--- a/rules/shapes.smk
+++ b/rules/shapes.smk
@@ -21,7 +21,7 @@ rule download_raw_gadm_administrative_borders:
     params: url = lambda wildcards: config["data-sources"]["gadm"].format(country_code=wildcards.country_code)
     output: protected("data/automatic/raw-gadm/{country_code}.zip")
     conda: "../envs/shell.yaml"
-    shell: "curl -sLo {output} '{params.url}'"
+    shell: "curl -sSLo {output} '{params.url}'"
 
 
 rule raw_gadm_administrative_borders:
@@ -57,7 +57,7 @@ rule download_raw_nuts_units:
     params: url = config["data-sources"]["nuts"]
     output: protected("data/automatic/raw-nuts-units.zip")
     conda: "../envs/shell.yaml"
-    shell: "curl -sLo {output} '{params.url}'"
+    shell: "curl -sSLo {output} '{params.url}'"
 
 
 rule administrative_borders_nuts:
@@ -106,7 +106,7 @@ rule download_eez:
     output: protected("data/automatic/eez.zip")
     params: url = config["data-sources"]["eez"]
     conda: "../envs/shell.yaml"
-    shell: "curl -sLo {output} '{params.url}'"
+    shell: "curl -sSLo {output} '{params.url}'"
 
 
 rule eez:

--- a/rules/transmission.smk
+++ b/rules/transmission.smk
@@ -8,7 +8,7 @@ rule download_entsoe_tyndp_zip:
     params: url = config["data-sources"]["entsoe-tyndp"]
     output: protected("data/automatic/raw-entsoe-tyndp.xlsx.zip")
     conda: "../envs/shell.yaml"
-    shell: "curl -sLo {output} '{params.url}'"
+    shell: "curl -sSLo {output} '{params.url}'"
 
 
 rule entsoe_tyndp_xlsx:

--- a/rules/transport.smk
+++ b/rules/transport.smk
@@ -8,7 +8,7 @@ rule download_transport_timeseries:
     conda: "../envs/shell.yaml"
     output: protected("data/automatic/ramp-ev-consumption-profiles.csv.gz")
     localrule: True
-    shell: "curl -sLo {output} {params.url}"
+    shell: "curl -sSLo {output} {params.url}"
 
 
 rule jrc_idees_transport_processed:

--- a/rules/wind-and-solar.smk
+++ b/rules/wind-and-solar.smk
@@ -13,7 +13,7 @@ rule download_potentials:
     params: url = config["data-sources"]["potentials"]
     output: protected("data/automatic/raw-potentials.zip")
     conda: "../envs/shell.yaml"
-    shell: "curl -sLo {output} '{params.url}'"
+    shell: "curl -sSLo {output} '{params.url}'"
 
 
 rule potentials:
@@ -37,7 +37,7 @@ rule download_capacity_factors_wind_and_solar:
     params: url = lambda wildcards: config["data-sources"]["capacity-factors"].format(filename=wildcards.filename)
     output: protected("data/automatic/capacityfactors/{filename}")
     conda: "../envs/shell.yaml"
-    shell: "curl -sLo {output} '{params.url}'"
+    shell: "curl -sSLo {output} '{params.url}'"
 
 
 rule area_to_capacity_limits:


### PR DESCRIPTION
The `s` option makes curl silent, including error messages. The newly added `S` option keeps curl silent but ensures error messages are not silent.

This is an improvement for #267 but not a fix.

## Checklist

Any checks which are not relevant to the PR can be pre-checked by the PR creator. All others should be checked by the reviewer. You can add extra checklist items here if required by the PR.

- [ ] CHANGELOG updated
- [ ] Minimal workflow tests pass
- [ ] Tests added to cover contribution
- [ ] Documentation updated
- [ ] Configuration schema updated
