### PR TITLE
Fix CHE transport historical data and CYP actual data

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -38,6 +38,7 @@ data-pre-processing:
             BIH: [HRV, HUN]
             MNE: [HRV]
             SRB: [HUN]
+            CYP: [ROU]
 root-directory: .
 cluster-sync:
     url: euler.ethz.ch

--- a/scripts/data/annual_energy_balance.py
+++ b/scripts/data/annual_energy_balance.py
@@ -194,21 +194,16 @@ def get_ch_waste_consumption(path_to_excel):
 
 def get_ch_transport_energy_balance(path_to_excel):
     carriers = {
-        "Elektrizität": "E7000",
-        "Gas übriger Vekehr": "G3000",
-        "Übrige erneuerbare Energien": "R5220B",
-        "davon Benzin": "O4652XR5210B",
-        "davon Diesel": "O4671XR5220B",
-        "davon Flugtreibstoffe": "O4000XBIO",
+        "Gas übriger Vekehr": ("G3000", "FC_TRA_ROAD_E"),
+        "Übrige erneuerbare Energien": ("R5220B", "FC_TRA_ROAD_E"),
+        "davon Benzin": ("O4652XR5210B", "FC_TRA_ROAD_E"),
+        "davon Diesel": ("O4671XR5220B", "FC_TRA_ROAD_E"),
+        "davon Flugtreibstoffe": ("O4000XBIO", "INTAVI"),
+        "davon Bahnen": ("E7000", "FC_TRA_RAIL_E"),
+        "davon Strasse": ("E7000", "FC_TRA_ROAD_E"),
     }
-    categories = {
-        "O4652XR5210B": "FC_TRA_ROAD_E",
-        "O4671XR5220B": "FC_TRA_ROAD_E",
-        "R5220B": "FC_TRA_ROAD_E",
-        "G3000": "FC_TRA_ROAD_E",
-        "E7000": "FC_TRA_RAIL_E",
-        "O4000XBIO": "INTAVI",
-    }
+    # ASSUME "davon Non-Road" is not included in electrified transport
+
     df = pd.read_excel(
         path_to_excel,
         skiprows=6,
@@ -219,6 +214,7 @@ def get_ch_transport_energy_balance(path_to_excel):
         na_values=["-"],
         header=[0, 1, 2, 3, 4],
     ).xs("TJ", level=-1, axis=1)
+
     # Footnote labels lead to some strings randomly ending in numbers; we remove them here
     remove_digits = str.maketrans("", "", digits)
     # carrier names span across two column levels, which we merge with fillna
@@ -233,14 +229,15 @@ def get_ch_transport_energy_balance(path_to_excel):
 
     df.columns = carrier_name_func(0).fillna(carrier_name_func(1)).values
 
-    return (
-        df.groupby(axis=1, level=0)
+    df = (
+        df
+        .groupby(axis=1, level=0)
         .sum()
         .rename_axis(index="year", columns="carrier_code")
-        .T.assign(cat_code=lambda df: df.index.map(categories))
-        .set_index("cat_code", append=True)
-        .stack()
+        .T
     )
+    df.index = pd.MultiIndex.from_tuples(df.index, names=('carrier_code', 'cat_code'))
+    return df.stack()
 
 
 def get_ch_industry_energy_balance(path_to_excel):

--- a/scripts/data/annual_energy_balance.py
+++ b/scripts/data/annual_energy_balance.py
@@ -230,13 +230,12 @@ def get_ch_transport_energy_balance(path_to_excel):
     df.columns = carrier_name_func(0).fillna(carrier_name_func(1)).values
 
     df = (
-        df
-        .groupby(axis=1, level=0)
+        df.groupby(axis=1, level=0)
         .sum()
         .rename_axis(index="year", columns="carrier_code")
         .T
     )
-    df.index = pd.MultiIndex.from_tuples(df.index, names=('carrier_code', 'cat_code'))
+    df.index = pd.MultiIndex.from_tuples(df.index, names=("carrier_code", "cat_code"))
     return df.stack()
 
 

--- a/scripts/transport/annual_transport_demand.py
+++ b/scripts/transport/annual_transport_demand.py
@@ -65,7 +65,6 @@ def get_all_distance_efficiency(
         .interpolate(axis=1, limit_direction="both")
         .stack()
     )
-
     # contribution of each transport mode to carrier consumption from JRC_IDEES
     # 2016-2018 from 2015 data; non-JRC countries, based on neighbour data
     carrier_contribution = fill_missing_countries_and_years(
@@ -74,7 +73,6 @@ def get_all_distance_efficiency(
         ),
         fill_missing_values,
     )
-
     # Energy consumption per transport mode by mapping transport mode
     # carrier contributions to total carrier consumption
     transport_energy_per_mode = carrier_contribution.mul(

--- a/scripts/transport/road_transport_timeseries.py
+++ b/scripts/transport/road_transport_timeseries.py
@@ -61,7 +61,6 @@ def create_road_transport_demand_timeseries(
         .tz_localize(None)
         .rename_axis("utc-timestamp")
     )
-
     assert not df_timeseries.isna().any(
         axis=None
     ), "There are NaN values in the timeseries dataframe"


### PR DESCRIPTION
Fixes #291  .

Supposed to fix #291 before the ch-stats and aerostats data are downloaded separately.

Co-authored by: Francesco Sanvito [sanvitofrancesco@gmail.com](mailto:sanvitofrancesco@gmail.com)

## Checklist

Any checks which are not relevant to the PR can be pre-checked by the PR creator. All others should be checked by the reviewer. You can add extra checklist items here if required by the PR.

- [ ] CHANGELOG updated
- [ ] Minimal workflow tests pass
- [ ] Tests added to cover contribution
- [ ] Documentation updated
- [ ] Configuration schema updated
