### PR TITLE
Update to snakemake 8.10.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * **UPDATE** the declaration of required cluster resources. Moving away from a mechanism that is deprecated in Snakemake (#211).
 * **UPDATE** default Snakemake profile to be activated automatically, for convenience (#264).
 * **UPDATE** default conda prefix directory including consistent handling of the path to eurocalliopelib (#264).
+* **UPDATE** snakemake to v8.10.6.
 
 ### Fixed (models)
 

--- a/Snakefile
+++ b/Snakefile
@@ -39,14 +39,16 @@ ALL_CF_TECHNOLOGIES = [
     "hydro-reservoir"
 ]
 
+
 def ensure_lib_folder_is_linked():
-    if not workflow.conda_prefix:
+    if not workflow.deployment_settings.conda_prefix:
         return
-    link = Path(workflow.conda_prefix) / "lib"
+    link = Path(workflow.deployment_settings.conda_prefix) / "lib"
     if not link.exists():
         print("Creating link from conda env dir to eurocalliopelib.")
-        makedirs(workflow.conda_prefix)
-        shell(f"ln -s {workflow.basedir}/lib {workflow.conda_prefix}/lib")
+        makedirs(workflow.deployment_settings.conda_prefix)
+        shell(f"ln -s {workflow.basedir}/lib {workflow.deployment_settings.conda_prefix}/lib")
+
 
 ensure_lib_folder_is_linked()
 
@@ -220,7 +222,7 @@ rule dag:
         "dot -Tpdf {input} -o build/dag.pdf"
 
 
-rule clean: # removes all generated results
+rule clean:  # removes all generated results
     shell:
         """
         rm -r build/

--- a/docs/workflow/build.md
+++ b/docs/workflow/build.md
@@ -22,12 +22,12 @@ Using either one, you can create the environment:
         # using mamba
         mamba env create -f environment.yaml --no-default-packages
         conda activate euro-calliope
-        snakemake --list # test your installation
+        snakemake --list-rules # test your installation
 
         # using conda
         conda env create -f environment.yaml --no-default-packages
         conda activate euro-calliope
-        snakemake --profile profiles/conda --list # test your installation
+        snakemake --profile profiles/conda --list-rules # test your installation
 
 3. Install a Gurobi license on your computer ([academic license](https://www.gurobi.com/downloads/end-user-license-agreement-academic/) comes at no cost), or [choose a different solver](../model/customisation.md#manual-changes).
 

--- a/environment.yaml
+++ b/environment.yaml
@@ -5,6 +5,6 @@ channels:
 dependencies:
     - python=3.11
     - pycountry=18.12.8
-    - snakemake-minimal=7.26.0
+    - snakemake-minimal=8.10.6
 variables:
     SNAKEMAKE_PROFILE: ./profiles/default

--- a/profiles/conda/config.yaml
+++ b/profiles/conda/config.yaml
@@ -1,4 +1,4 @@
-use-conda: True
+software-deployment-method: conda
 conda-frontend: conda
 cores: 2
 conda-prefix: ../envs/snakemake/euro-calliope/

--- a/profiles/default/config.yaml
+++ b/profiles/default/config.yaml
@@ -1,4 +1,3 @@
-use-conda: True
-conda-frontend: mamba
+software-deployment-method: conda
 cores: 2
 conda-prefix: ../envs/snakemake/euro-calliope/

--- a/profiles/euler/config.yaml
+++ b/profiles/euler/config.yaml
@@ -3,7 +3,7 @@ jobs: 999
 local-cores: 1
 latency-wait: 60
 use-envmodules: True
-use-conda: True
+software-deployment-method: conda
 conda-prefix: ../envs/snakemake/euro-calliope/
 default-resources: [
     "runtime=10",


### PR DESCRIPTION
Fixes #289.

The required changes seem rather minimal. The minimal config successfully runs. `use-conda` is deprecated and I replaced it with `software-deployment-method: conda`.

## Checklist

Any checks which are not relevant to the PR can be pre-checked by the PR creator. All others should be checked by the reviewer. You can add extra checklist items here if required by the PR.

- [ ] CHANGELOG updated
- [ ] Minimal workflow tests pass
- [ ] Tests added to cover contribution
- [ ] Documentation updated
- [ ] Configuration schema updated
