### PR TITLE
Improve creation of symlink to eurocalliopelib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 
 * **FIX** fixed optimisation tolerance of hydro power plants from xtol to xatol (#266).
 * **FIX** fixed rule `download_basins_database`, which previously failed on some linux and mac machines, by requiring a more recent curl in the environment `envs/shell.yaml` (#267).
+* **FIX** fixed creation of symlink to eurocalliopelib if workflow directory has been moved or renamed.
 
 ## 1.1.0 (2021-12-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@
 * **UPDATE** cluster sync infrastructure to retain file permission defaults on the cluster. This change improves team collaboration, as default group settings will apply to the files on the cluster (#214).
 * **UPDATE** the declaration of required cluster resources. Moving away from a mechanism that is deprecated in Snakemake (#211).
 * **UPDATE** default Snakemake profile to be activated automatically, for convenience (#264).
-* **UPDATE** default conda prefix directory including consistent handling of the path to eurocalliopelib (#264).
+* **UPDATE** default conda prefix directory including consistent handling of the path to eurocalliopelib (#264, #331).
 
 ### Fixed (models)
 
@@ -57,7 +57,6 @@
 
 * **FIX** fixed optimisation tolerance of hydro power plants from xtol to xatol (#266).
 * **FIX** fixed rule `download_basins_database`, which previously failed on some linux and mac machines, by requiring a more recent curl in the environment `envs/shell.yaml` (#267).
-* **FIX** fixed creation of symlink to eurocalliopelib if workflow directory has been moved or renamed.
 
 ## 1.1.0 (2021-12-22)
 

--- a/Snakefile
+++ b/Snakefile
@@ -44,7 +44,8 @@ def ensure_lib_folder_is_linked():
     if not workflow.conda_prefix:
         return
     link = Path(workflow.conda_prefix) / "lib"
-    if not link.exists():  # Returns False if link exists but is an invalid symlink
+    if not link.exists():
+        # Link either does not exist or is an invalid symlink
         print("Creating link from conda env dir to eurocalliopelib.")
         if link.is_symlink():  # Deal with existing but invalid symlink
             shell(f"rm {link}")

--- a/Snakefile
+++ b/Snakefile
@@ -39,14 +39,18 @@ ALL_CF_TECHNOLOGIES = [
     "hydro-reservoir"
 ]
 
+
 def ensure_lib_folder_is_linked():
     if not workflow.conda_prefix:
         return
     link = Path(workflow.conda_prefix) / "lib"
-    if not link.exists():
+    if not link.exists():  # Returns False if link exists but is an invalid symlink
         print("Creating link from conda env dir to eurocalliopelib.")
+        if link.is_symlink():  # Deal with existing but invalid symlink
+            shell(f"rm {link}")
         makedirs(workflow.conda_prefix)
-        shell(f"ln -s {workflow.basedir}/lib {workflow.conda_prefix}/lib")
+        shell(f"ln -s {workflow.basedir}/lib {link}")
+
 
 ensure_lib_folder_is_linked()
 


### PR DESCRIPTION
Fixes a newly-identified issue where if you move or rename the workflow directory after already having run once, `ensure_lib_folder_is_linked` does not work because the symlink exists but points at an invalid location.

## Checklist

Any checks which are not relevant to the PR can be pre-checked by the PR creator. All others should be checked by the reviewer. You can add extra checklist items here if required by the PR.

- [x] CHANGELOG updated
- [x] Minimal workflow tests pass
- [x] Tests added to cover contribution
- [x] Documentation updated
- [x] Configuration schema updated
