### PR TITLE
Update EEZ file ref to our own cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 ### Fixed (workflow)
 
 * **FIX** fixed optimisation tolerance of hydro power plants from xtol to xatol (#266).
+* **FIX** source of Exclusive Economic Zones (EEZ) to use a cache on [euro-calliope-datasets](https://github.com/calliope-project/euro-calliope-datasets) so that we can keep using v11 (#332).
 
 ## 1.1.0 (2021-12-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@
 ### Fixed (workflow)
 
 * **FIX** fixed optimisation tolerance of hydro power plants from xtol to xatol (#266).
-* **FIX** source of Exclusive Economic Zones (EEZ) to use a cache on [zenodo](https://sandbox.zenodo.org/records/45135) so that we can keep using v11 (#332).
+* **FIX** source of Exclusive Economic Zones (EEZ) to use a cache on [zenodo](https://sandbox.zenodo.org/records/45135) so that we can keep using v11 (#332).  FIXME: update to actual zenodo record before next Euro-Calliope release.
 * **FIX** fixed rule `download_basins_database`, which previously failed on some linux and mac machines, by requiring a more recent curl in the environment `envs/shell.yaml` (#267).
 
 ## 1.1.0 (2021-12-22)

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,7 +1,7 @@
 # For descriptions of the configuration values, see `./schema.yaml`.
 data-sources:
     biofuel-potentials-and-costs: https://cidportal.jrc.ec.europa.eu/ftp/jrc-opendata/ENSPRESO/ENSPRESO_BIOMASS.xlsx
-    eez: https://raw.githubusercontent.com/calliope-project/euro-calliope-datasets/add-eez/eez/eez.gpkg.zip # FIXME move to Zenodo?
+    eez: https://sandbox.zenodo.org/records/45135/files/eez_v11.gpkg.zip?download=1
     hydro-generation: https://zenodo.org/record/5797549/files/hydro-generation.csv?download=1
     national-phs-storage-capacities: https://zenodo.org/record/5797549/files/pumped-hydro-storage-capacities-gwh.csv?download=1
     capacity-factors: https://zenodo.org/record/3899687/files/{filename}?download=1

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,7 +1,7 @@
 # For descriptions of the configuration values, see `./schema.yaml`.
 data-sources:
     biofuel-potentials-and-costs: https://cidportal.jrc.ec.europa.eu/ftp/jrc-opendata/ENSPRESO/ENSPRESO_BIOMASS.xlsx
-    eez: https://sandbox.zenodo.org/records/45135/files/eez_v11.gpkg.zip?download=1
+    eez: https://sandbox.zenodo.org/records/45135/files/eez_v11.gpkg.zip?download=1  # FIXME: update to actual zenodo record before next Euro-Calliope release.
     hydro-generation: https://zenodo.org/record/5797549/files/hydro-generation.csv?download=1
     national-phs-storage-capacities: https://zenodo.org/record/5797549/files/pumped-hydro-storage-capacities-gwh.csv?download=1
     capacity-factors: https://zenodo.org/record/3899687/files/{filename}?download=1
@@ -14,8 +14,8 @@ data-sources:
     entsoe-tyndp: https://2020.entsos-tyndp-scenarios.eu/wp-content/uploads/2020/06/TYNDP-2020-Scenario-Datafile.xlsx.zip
     jrc-ppdb: https://zenodo.org/record/3574566/files/JRC-PPDB-OPEN.ver1.0.zip
     jrc-idees: https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/JRC-IDEES/JRC-IDEES-2015_v1/JRC-IDEES-2015_All_xlsx_{country_code}.zip
-    eurostat-energy-balance: https://raw.githubusercontent.com/calliope-project/euro-calliope-datasets/feature-sector-coupling/eurostat/nrg_bal_c.tsv.gz # FIXME do not use cached data
-    eurostat-hh-end-use:  https://raw.githubusercontent.com/calliope-project/euro-calliope-datasets/feature-sector-coupling/eurostat/nrg_d_hhq.tsv.gz # FIXME do not use cached data
+    eurostat-energy-balance: https://raw.githubusercontent.com/calliope-project/euro-calliope-datasets/feature-sector-coupling/eurostat/nrg_bal_c.tsv.gz # FIXME: move to zenodo
+    eurostat-hh-end-use:  https://raw.githubusercontent.com/calliope-project/euro-calliope-datasets/feature-sector-coupling/eurostat/nrg_d_hhq.tsv.gz # FIXME: move to zenodo
     swiss-end-use: https://www.bfe.admin.ch/bfe/en/home/versorgung/statistik-und-geodaten/energiestatistiken/energieverbrauch-nach-verwendungszweck.exturl.html/aHR0cHM6Ly9wdWJkYi5iZmUuYWRtaW4uY2gvZGUvcHVibGljYX/Rpb24vZG93bmxvYWQvOTg1NA==.html
     swiss-energy-balance: https://www.bfe.admin.ch/bfe/en/home/versorgung/statistik-und-geodaten/energiestatistiken/gesamtenergiestatistik.exturl.html/aHR0cHM6Ly9wdWJkYi5iZmUuYWRtaW4uY2gvZGUvcHVibGljYX/Rpb24vZG93bmxvYWQvNzUxOQ==.html
     swiss-industry-energy-balance: https://www.bfe.admin.ch/bfe/en/home/versorgung/statistik-und-geodaten/energiestatistiken/teilstatistiken.exturl.html/aHR0cHM6Ly9wdWJkYi5iZmUuYWRtaW4uY2gvZGUvcHVibGljYX/Rpb24vZG93bmxvYWQvODc4OA==.html

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,7 +1,7 @@
 # For descriptions of the configuration values, see `./schema.yaml`.
 data-sources:
     biofuel-potentials-and-costs: https://cidportal.jrc.ec.europa.eu/ftp/jrc-opendata/ENSPRESO/ENSPRESO_BIOMASS.xlsx
-    eez: https://geo.vliz.be/geoserver/MarineRegions/wfs?service=WFS&version=1.0.0&request=GetFeature&typeNames=MarineRegions:eez&outputFormat=SHAPE-ZIP
+    eez: https://raw.githubusercontent.com/calliope-project/euro-calliope-datasets/add-eez/eez/eez.gpkg.zip # FIXME move to Zenodo?
     hydro-generation: https://zenodo.org/record/5797549/files/hydro-generation.csv?download=1
     national-phs-storage-capacities: https://zenodo.org/record/5797549/files/pumped-hydro-storage-capacities-gwh.csv?download=1
     capacity-factors: https://zenodo.org/record/3899687/files/{filename}?download=1

--- a/rules/shapes.smk
+++ b/rules/shapes.smk
@@ -121,7 +121,7 @@ rule eez:
     shell:
         """
         fio cat --bbox {params.bounds} "zip://{input}"\
-        | fio filter "f.properties.territory1 in [{params.countries}]"\
+        | fio filter "f.properties.TERRITORY1 in [{params.countries}]"\
         | fio collect > {output}
         """
 

--- a/rules/shapes.smk
+++ b/rules/shapes.smk
@@ -103,7 +103,7 @@ rule units_without_shape:
 
 rule download_eez:
     message: "Download Exclusive Economic Zones as zip"
-    output: protected("data/automatic/eez.zip")
+    output: protected("data/automatic/eez.gpkg.zip")
     params: url = config["data-sources"]["eez"]
     conda: "../envs/shell.yaml"
     shell: "curl -sLo {output} '{params.url}'"

--- a/scripts/wind-and-solar/capacityfactors_offshore.py
+++ b/scripts/wind-and-solar/capacityfactors_offshore.py
@@ -22,7 +22,7 @@ def capacityfactors(
     final_year=None,
 ):
     """Generate offshore capacityfactor time series for each location."""
-    eez = gpd.read_file(path_to_eez).set_index("mrgid").to_crs(EPSG3035).geometry
+    eez = gpd.read_file(path_to_eez).set_index("MRGID").to_crs(EPSG3035).geometry
     shared_coast = pd.read_csv(path_to_shared_coast, index_col=0)
     shared_coast.index = shared_coast.index.map(lambda x: x.replace(".", "-"))
     shared_coast.columns = shared_coast.columns.astype(int)
@@ -83,11 +83,11 @@ if __name__ == "__main__":
         path_to_timeseries=snakemake.input.timeseries,
         cf_threshold=float(snakemake.params.cf_threshold),
         gridcell_overlap_threshold=float(snakemake.params.gridcell_overlap_threshold),
-        first_year=str(snakemake.params.first_year)
-        if snakemake.params.trim_ts
-        else None,
-        final_year=str(snakemake.params.final_year)
-        if snakemake.params.trim_ts
-        else None,
+        first_year=(
+            str(snakemake.params.first_year) if snakemake.params.trim_ts else None
+        ),
+        final_year=(
+            str(snakemake.params.final_year) if snakemake.params.trim_ts else None
+        ),
         path_to_result=snakemake.output[0],
     )


### PR DESCRIPTION
Fixes #328 

The issue is a newer version of EEZ is being downloaded, which we can't control for on the `https://geo.vliz.be/geoserver/MarineRegions/wfs` file server. Versioned releases _are_ available [here](https://www.marineregions.org/downloads.php), but require a user to tick a box and fill in some info about themselves. The data license allows us to just upload it elsewhere, which I've done by putting it on the [`euro-calliope-datasets` repo](https://github.com/calliope-project/euro-calliope-datasets/pull/5). Arguably not the best way to handle caching a working version of EEZ (in this case, EEZ V11) but it is possibly the quickest.

Tested on the full workflow and it works to produce offshore wind data. Change from the v1.1 pre-built CSV file (average of hourly new cf / hourly old cf per country):

> [!NOTE]
> EDIT: Using high res EEZ data, the result is a 1:1 mapping now. No change in data.

```
AUT         NaN
BEL    1.000087
BGR    0.999992
HRV    0.999954
CYP    0.999995
CZE         NaN
DNK    0.999905
EST    0.999875
FIN    0.999110
FRA    1.000038
DEU    1.000079
GRC    0.999975
HUN         NaN
IRL    1.000002
ITA    0.999969
LVA    1.000151
LTU    0.999934
LUX         NaN
NLD    1.000147
POL    1.000209
PRT    1.000019
ROU    0.999999
SVK         NaN
SVN    0.998619
ESP    0.999996
SWE    0.999313
GBR    1.000024
ALB    1.000064
BIH    1.000000
MKD         NaN
MNE    0.999882
NOR    0.999733
SRB         NaN
CHE         NaN
```



## Checklist

Any checks which are not relevant to the PR can be pre-checked by the PR creator. All others should be checked by the reviewer. You can add extra checklist items here if required by the PR.

- [ ] CHANGELOG updated
- [ ] Minimal workflow tests pass
- [ ] Tests added to cover contribution
- [ ] Documentation updated
- [ ] Configuration schema updated
