### PR TITLE
Add gridded heat demand timeseries

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -20,6 +20,7 @@ data-sources:
     swiss-energy-balance: https://www.bfe.admin.ch/bfe/en/home/versorgung/statistik-und-geodaten/energiestatistiken/gesamtenergiestatistik.exturl.html/aHR0cHM6Ly9wdWJkYi5iZmUuYWRtaW4uY2gvZGUvcHVibGljYX/Rpb24vZG93bmxvYWQvNzUxOQ==.html
     swiss-industry-energy-balance: https://www.bfe.admin.ch/bfe/en/home/versorgung/statistik-und-geodaten/energiestatistiken/teilstatistiken.exturl.html/aHR0cHM6Ly9wdWJkYi5iZmUuYWRtaW4uY2gvZGUvcHVibGljYX/Rpb24vZG93bmxvYWQvODc4OA==.html
     ev-data: https://zenodo.org/record/6579421/files/ramp-ev-consumption-profiles.csv.gz?download=1
+    gridded-temperature-data: https://zenodo.org/records/6557643/files/temperature.nc?download=1
 data-pre-processing:
     fill-missing-values:
         jrc-idees:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -21,7 +21,9 @@ data-sources:
     swiss-industry-energy-balance: https://www.bfe.admin.ch/bfe/en/home/versorgung/statistik-und-geodaten/energiestatistiken/teilstatistiken.exturl.html/aHR0cHM6Ly9wdWJkYi5iZmUuYWRtaW4uY2gvZGUvcHVibGljYX/Rpb24vZG93bmxvYWQvODc4OA==.html
     ev-data: https://zenodo.org/record/6579421/files/ramp-ev-consumption-profiles.csv.gz?download=1
     gridded-temperature-data: https://zenodo.org/records/6557643/files/temperature.nc?download=1
+    gridded-10m-windspeed-data: https://zenodo.org/records/6557643/files/wind10m.nc?download=1
     when2heat-params: https://raw.githubusercontent.com/oruhnau/when2heat/351bd1a2f9392ed50a7bdb732a103c9327c51846/input/bgw_bdew/{dataset}
+    population: https://ec.europa.eu/eurostat/cache/GISCO/geodatafiles/JRC_GRID_2018.zip
 data-pre-processing:
     fill-missing-values:
         jrc-idees:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -21,6 +21,7 @@ data-sources:
     swiss-industry-energy-balance: https://www.bfe.admin.ch/bfe/en/home/versorgung/statistik-und-geodaten/energiestatistiken/teilstatistiken.exturl.html/aHR0cHM6Ly9wdWJkYi5iZmUuYWRtaW4uY2gvZGUvcHVibGljYX/Rpb24vZG93bmxvYWQvODc4OA==.html
     ev-data: https://zenodo.org/record/6579421/files/ramp-ev-consumption-profiles.csv.gz?download=1
     gridded-temperature-data: https://zenodo.org/records/6557643/files/temperature.nc?download=1
+    when2heat-params: https://raw.githubusercontent.com/oruhnau/when2heat/351bd1a2f9392ed50a7bdb732a103c9327c51846/input/bgw_bdew/{dataset}
 data-pre-processing:
     fill-missing-values:
         jrc-idees:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -22,7 +22,7 @@ data-sources:
     ev-data: https://zenodo.org/record/6579421/files/ramp-ev-consumption-profiles.csv.gz?download=1
     gridded-temperature-data: https://zenodo.org/records/6557643/files/temperature.nc?download=1
     gridded-10m-windspeed-data: https://zenodo.org/records/6557643/files/wind10m.nc?download=1
-    when2heat-params: https://raw.githubusercontent.com/oruhnau/when2heat/351bd1a2f9392ed50a7bdb732a103c9327c51846/input/bgw_bdew/{dataset}
+    when2heat-params: https://zenodo.org/records/10965295/files/{dataset}?download=1
     population: https://ec.europa.eu/eurostat/cache/GISCO/geodatafiles/JRC_GRID_2018.zip
 data-pre-processing:
     fill-missing-values:

--- a/config/schema.yaml
+++ b/config/schema.yaml
@@ -107,6 +107,10 @@ properties:
                 type: string
                 pattern: ^(https?|http?):\/\/.+
                 description: Web address of electric vehicle data.
+            gridded-temperature-data:
+                type: string
+                pattern: ^(https?|http?):\/\/.+
+                description: "Web address of gridded temperature data. Expecting a netCDF file with the coordinates [time, site], and the variables [temperature, lat, lon]."
     data-pre-processing:
         type: object
         description: Parameters for the pre-processing of raw data.

--- a/config/schema.yaml
+++ b/config/schema.yaml
@@ -111,10 +111,18 @@ properties:
                 type: string
                 pattern: ^(https?|http?):\/\/.+
                 description: "Web address of gridded temperature data. Expecting a netCDF file with the coordinates [time, site], and the variables [temperature, lat, lon]."
+            gridded-10m-windspeed-data:
+                type: string
+                pattern: ^(https?|http?):\/\/.+
+                description: "Web address of gridded 10m wind speed data. Expecting a netCDF file with the coordinates [time, site], and the variables [temperature, lat, lon]."
             when2heat-params:
                 type: string
                 pattern: ^(https?|http?):\/\/.+
                 description: "Web address of When2Heat parameters for heat demand profiles."
+            population:
+                type: string
+                pattern: ^(https?|http?):\/\/.+
+                description: "Web address of population data."
     data-pre-processing:
         type: object
         description: Parameters for the pre-processing of raw data.

--- a/config/schema.yaml
+++ b/config/schema.yaml
@@ -111,6 +111,10 @@ properties:
                 type: string
                 pattern: ^(https?|http?):\/\/.+
                 description: "Web address of gridded temperature data. Expecting a netCDF file with the coordinates [time, site], and the variables [temperature, lat, lon]."
+            when2heat-params:
+                type: string
+                pattern: ^(https?|http?):\/\/.+
+                description: "Web address of When2Heat parameters for heat demand profiles."
     data-pre-processing:
         type: object
         description: Parameters for the pre-processing of raw data.

--- a/docs/about/references.md
+++ b/docs/about/references.md
@@ -64,3 +64,11 @@ Department for Business, Energy and Industrial Strategy (2016). <i>Electricity G
 ### @Mantzos:2017
 
 Mantzos, L., Wiesenthal, T., Matei, N. A., Tchung-Ming, S., Rozsai, M., Russ, P., & Ramirez, A. S. (2017). JRC-IDEES: Integrated Database of the European Energy Sector: Methodological note. JRC Research Reports, Article JRC108244. https://ideas.repec.org//p/ipt/iptwpa/jrc108244.html
+
+### @Ruhnau:2019
+
+Ruhnau, O., Hirth, L. & Praktiknjo, A. Time series of heat demand and heat pump efficiency for energy system modeling. Sci Data 6, 189 (2019). https://doi.org/10.1038/s41597-019-0199-y
+
+### @BDEW:2015
+
+German Association of Energy and Water Industries (BDEW), German Association of Local Utilities (VKU) & European Association of Loacal Energy Distributors (GEODE). Abwicklung von Standardlastprofilen Gas [Execution of Gas Standard Load Profiles]. Guidelines (BDEW, 2015). [https://www.bdew.de/media/documents/Leitfaden_20160630_Abwicklung-Standardlastprofile-Gas.pdf](https://www.bdew.de/media/documents/Leitfaden_20160630_Abwicklung-Standardlastprofile-Gas.pdf)

--- a/envs/default.yaml
+++ b/envs/default.yaml
@@ -7,6 +7,7 @@ dependencies:
     - ipdb=0.13.13
     - numpy=1.20.2
     - pandas=1.2.3
+    - bottleneck=1.3.2
     - xlrd=2.0.1
     - openpyxl=3.0.7
     - pycountry=18.12.8

--- a/rules/data.smk
+++ b/rules/data.smk
@@ -97,3 +97,14 @@ rule download_gridded_temperature_data:
     conda: "../envs/shell.yaml"
     localrule: True
     shell: "curl -sSLo {output} '{params.url}'"
+
+
+rule download_when2heat_params:
+    message: "Get parameters for heat demand profiles from the When2Heat project repository"
+    output: directory("data/automatic/when2heat")
+    params:
+        url = lambda wildcards: config["data-sources"]["when2heat-params"].format(dataset=
+            "{" + ",".join(["daily_demand.csv", "hourly_factors_COM.csv", "hourly_factors_MFH.csv", "hourly_factors_SFH.csv"]) + "}"
+        )
+    conda: "../envs/shell.yaml"
+    shell: "mkdir -p {output} && curl -sSLo '{output}/#1' '{params.url}'"

--- a/rules/data.smk
+++ b/rules/data.smk
@@ -83,10 +83,17 @@ rule jrc_idees_unzipped:
     mv build/data/jrc-idees/{wildcards.sector}/unprocessed/{params.file_name} {output}
     """
 
-
 "EU28 county codes used for downloading JRC-IDEES"
 JRC_IDEES_SCOPE = [
     "AT", "BE", "BG", "CY", "CZ", "DE", "DK", "EE", "EL", "ES", "FI", "FR",
     "HR", "HU", "IE", "IT", "LT", "LU", "LV", "MT", "NL", "PL", "PT", "RO",
     "SE", "SI", "SK", "UK"
 ]
+
+rule download_gridded_temperature_data:
+    message: "Download gridded temperature data"
+    params: url = config["data-sources"]["gridded-temperature-data"]
+    output: protected("data/automatic/gridded-weather/temperature.nc")
+    conda: "../envs/shell.yaml"
+    localrule: True
+    shell: "curl -sSLo {output} '{params.url}'"

--- a/rules/data.smk
+++ b/rules/data.smk
@@ -90,34 +90,6 @@ JRC_IDEES_SCOPE = [
     "SE", "SI", "SK", "UK"
 ]
 
-rule download_gridded_temperature_data:
-    message: "Download gridded temperature data"
-    params: url = config["data-sources"]["gridded-temperature-data"]
-    output: protected("data/automatic/gridded-weather/temperature.nc")
-    conda: "../envs/shell.yaml"
-    localrule: True
-    shell: "curl -sSLo {output} '{params.url}'"
-
-
-rule download_gridded_10m_windspeed_data:
-    message: "Download gridded 10m wind speed data"
-    params: url = config["data-sources"]["gridded-10m-windspeed-data"]
-    output: protected("data/automatic/gridded-weather/wind10m.nc")
-    conda: "../envs/shell.yaml"
-    localrule: True
-    shell: "curl -sSLo {output} '{params.url}'"
-
-
-rule download_when2heat_params:
-    message: "Get parameters for heat demand profiles from the When2Heat project repository"
-    output: directory("data/automatic/when2heat")
-    params:
-        url = lambda wildcards: config["data-sources"]["when2heat-params"].format(dataset=
-            "{" + ",".join(["daily_demand.csv", "hourly_factors_COM.csv", "hourly_factors_MFH.csv", "hourly_factors_SFH.csv"]) + "}"
-        )
-    conda: "../envs/shell.yaml"
-    shell: "mkdir -p {output} && curl -sSLo '{output}/#1' '{params.url}'"
-
 rule download_raw_population_zipped:
     message: "Download population data."
     output:

--- a/rules/data.smk
+++ b/rules/data.smk
@@ -99,6 +99,15 @@ rule download_gridded_temperature_data:
     shell: "curl -sSLo {output} '{params.url}'"
 
 
+rule download_gridded_10m_windspeed_data:
+    message: "Download gridded 10m wind speed data"
+    params: url = config["data-sources"]["gridded-10m-windspeed-data"]
+    output: protected("data/automatic/gridded-weather/wind10m.nc")
+    conda: "../envs/shell.yaml"
+    localrule: True
+    shell: "curl -sSLo {output} '{params.url}'"
+
+
 rule download_when2heat_params:
     message: "Get parameters for heat demand profiles from the When2Heat project repository"
     output: directory("data/automatic/when2heat")
@@ -108,3 +117,19 @@ rule download_when2heat_params:
         )
     conda: "../envs/shell.yaml"
     shell: "mkdir -p {output} && curl -sSLo '{output}/#1' '{params.url}'"
+
+rule download_raw_population_zipped:
+    message: "Download population data."
+    output:
+        protected("data/automatic/raw-population-data.zip")
+    params: url = config["data-sources"]["population"]
+    conda: "../envs/shell.yaml"
+    shell: "curl -sSLo {output} '{params.url}'"
+
+
+rule raw_population_unzipped:
+    message: "Extract population data TIF."
+    input: rules.download_raw_population_zipped.output
+    output: temp("build/JRC_1K_POP_2018.tif")
+    conda: "../envs/shell.yaml"
+    shell: "unzip {input} '*.tif' -d ./build/"

--- a/rules/heat.smk
+++ b/rules/heat.smk
@@ -97,5 +97,5 @@ rule gridded_unscaled_heat_profiles:
         lat_name = "lat",
         lon_name = "lon",
     conda: "../envs/default.yaml"
-    output: temp("build/data/{resolution}/gridded_hourly_unscaled_heat_demand_{year}.nc")
+    output: "build/data/{resolution}/gridded_hourly_unscaled_heat_demand_{year}.nc"
     script: "../scripts/heat/gridded_unscaled_heat_profiles.py"

--- a/rules/heat.smk
+++ b/rules/heat.smk
@@ -69,3 +69,18 @@ use rule create_heat_demand_timeseries as create_heat_demand_timeseries_historic
         power_scaling_factor = config["scaling-factors"]["power"],
     output:
         "build/models/{resolution}/timeseries/demand/heat-demand-historic-electrification.csv",
+
+rule population_per_weather_gridbox:
+    message: "Get {wildcards.resolution} population information per weather data gridbox"
+    input:
+        script = "scripts/heat/population_per_gridbox.py",
+        wind_speed = rules.download_gridded_10m_windspeed_data.output[0],
+        population = rules.raw_population_unzipped.output[0],
+        locations = rules.units.output[0]
+    params:
+        lat_name = "lat",
+        lon_name = "lon",
+    conda: "../envs/geo.yaml"
+    output: "build/data/{resolution}/population.nc"
+    script: "../scripts/heat/population_per_gridbox.py"
+

--- a/rules/heat.smk
+++ b/rules/heat.smk
@@ -84,3 +84,18 @@ rule population_per_weather_gridbox:
     output: "build/data/{resolution}/population.nc"
     script: "../scripts/heat/population_per_gridbox.py"
 
+
+rule gridded_unscaled_heat_profiles:
+    message: "Generate gridded heat demand profile shapes for {wildcards.year} from weather and population data"
+    input:
+        script = "scripts/heat/gridded_unscaled_heat_profiles.py",
+        population = rules.population_per_weather_gridbox.output[0],
+        wind_speed = rules.download_gridded_10m_windspeed_data.output[0],
+        temperature = rules.download_gridded_temperature_data.output[0],
+        when2heat = rules.download_when2heat_params.output[0]
+    params:
+        lat_name = "lat",
+        lon_name = "lon",
+    conda: "../envs/default.yaml"
+    output: temp("build/data/{resolution}/gridded_hourly_unscaled_heat_demand_{year}.nc")
+    script: "../scripts/heat/gridded_unscaled_heat_profiles.py"

--- a/scripts/heat/gridded_unscaled_heat_profiles.py
+++ b/scripts/heat/gridded_unscaled_heat_profiles.py
@@ -28,6 +28,13 @@ def get_unscaled_heat_profiles(
     wind_ds = xr.open_dataset(path_to_wind_speed).rename({lon_name: "x", lat_name: "y"})
     wind_da = wind_ds["wind_speed"].mean("time")
 
+    # Subset temperature to the selected year extended by a couple of days either end,
+    # so we don't compute values for years we don't need, but keep a buffer for the shifts
+    # happening in get_reference_temperature()
+    temperature_ds = temperature_ds.sel(
+        time=slice(str(int(year) - 1) + "-12-25", str(int(year) + 1) + "-01-05")
+    )
+
     # This is a weighted average temperature from 3 days prior to each day in the timeseries
     # to represent the relative impact of historical daily temperature on the heat demand of each day.
     # See [@Ruhnau:2019] for more information on the method

--- a/scripts/heat/gridded_unscaled_heat_profiles.py
+++ b/scripts/heat/gridded_unscaled_heat_profiles.py
@@ -24,12 +24,10 @@ def get_unscaled_heat_profiles(
     year: Union[str, int],
 ) -> None:
     population = xr.open_dataarray(path_to_population)
-    temperature_ds = xr.open_dataset(path_to_temperature).rename(
-        {
-            lon_name: "x",
-            lat_name: "y",
-        }
-    )
+    temperature_ds = xr.open_dataset(path_to_temperature).rename({
+        lon_name: "x",
+        lat_name: "y",
+    })
     # Only need site-wide mean wind speed for this analysis
     wind_ds = xr.open_dataset(path_to_wind_speed).rename({lon_name: "x", lat_name: "y"})
     average_wind_speed = wind_ds["wind_speed"].mean("time")

--- a/scripts/heat/gridded_unscaled_heat_profiles.py
+++ b/scripts/heat/gridded_unscaled_heat_profiles.py
@@ -23,6 +23,13 @@ def get_unscaled_heat_profiles(
     out_path: str,
     year: Union[str, int],
 ) -> None:
+    """
+    Produces time series of heat demand profiles with the correct shape, and consistent
+    within themselves, but without meaningful units.
+    The profiles need to be scaled so their magnitude matches annual heat demand data
+    in a subsequent step.
+
+    """
     population = xr.open_dataarray(path_to_population)
     temperature_ds = xr.open_dataset(path_to_temperature).rename({
         lon_name: "x",

--- a/scripts/heat/gridded_unscaled_heat_profiles.py
+++ b/scripts/heat/gridded_unscaled_heat_profiles.py
@@ -21,9 +21,10 @@ def get_unscaled_heat_profiles(
     year,
 ):
     population = xr.open_dataarray(path_to_population)
-    temperature_ds = xr.open_dataset(path_to_temperature).rename(
-        {lon_name: "x", lat_name: "y"}
-    )
+    temperature_ds = xr.open_dataset(path_to_temperature).rename({
+        lon_name: "x",
+        lat_name: "y",
+    })
     # Only need site-wide mean wind speed for this analysis
     wind_ds = xr.open_dataset(path_to_wind_speed).rename({lon_name: "x", lat_name: "y"})
     wind_da = wind_ds["wind_speed"].mean("time")

--- a/scripts/heat/gridded_unscaled_heat_profiles.py
+++ b/scripts/heat/gridded_unscaled_heat_profiles.py
@@ -1,0 +1,209 @@
+"""
+Use weather data to simulate hourly heat profiles using When2Heat (https://github.com/oruhnau/when2heat) data processing pipline.
+Functions attributable to When2Heat are explictily referenced as such in the function docstring.
+"""
+
+import os
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+
+def get_unscaled_heat_profiles(
+    path_to_population,
+    path_to_wind_speed,
+    path_to_temperature,
+    path_to_when2heat_params,
+    lat_name,
+    lon_name,
+    out_path,
+    year,
+):
+    population = xr.open_dataarray(path_to_population)
+    temperature_ds = xr.open_dataset(path_to_temperature).rename(
+        {lon_name: "x", lat_name: "y"}
+    )
+    # Only need site-wide mean wind speed for this analysis
+    wind_ds = xr.open_dataset(path_to_wind_speed).rename({lon_name: "x", lat_name: "y"})
+    wind_da = wind_ds["wind_speed"].mean("time")
+
+    # This is a weighted average temperature from 3 days prior to each day in the timeseries
+    # to represent the relative impact of historical daily temperature on the heat demand of each day.
+    # See [@Ruhnau:2019] for more information on the method
+    reference_temperature = get_reference_temperature(
+        temperature_ds["temperature"], time_dim="time"
+    )
+
+    # Parameters and how to apply them is based on [@BDEW:2015]
+    daily_params = read_daily_parameters(path_to_when2heat_params)
+    hourly_params = read_hourly_parameters(path_to_when2heat_params)
+
+    # Get daily demand
+    daily_heat = get_daily_heat_demand(reference_temperature, wind_da, daily_params)
+
+    # Map profiles to daily demand
+    hourly_heat = get_hourly_heat_profiles(
+        reference_temperature, daily_heat, hourly_params
+    )
+
+    # population weighted profiles.
+    # NOTE: profile magnitude is now only consistent within each region, not between them
+    weight = population / population.sum(["x", "y"])
+    # `hourly_heat` has dims [x, y, datetime], `weight` has dims [x, y, id],
+    # we want a final array with dims [id, datetime]
+    grouped_hourly_heat = xr.concat(
+        [(hourly_heat * weight.sel({"id": id})).sum(["x", "y"]) for id in weight.id],
+        dim="id",
+    )
+
+    grouped_hourly_heat.loc[{"time": str(year)}].to_netcdf(out_path)
+
+
+def get_hourly_heat_profiles(reference_temperature, daily_heat, hourly_params):
+    # Heavily modified from https://github.com/oruhnau/when2heat/blob/351bd1a2f9392ed50a7bdb732a103c9327c51846/scripts/demand.py
+    # to work with xarray datasets and to improve efficiency
+
+    # get temperature in 5C increments between -15C and +30C
+    temperature_increments = (
+        (np.ceil(((reference_temperature - 273.15) / 5).astype("float64")) * 5)
+        .clip(min=-15, max=30)
+        .to_series()
+    )
+    # Profiles are linked to the day's temperature increment, so we align the two
+    increment_index = (
+        temperature_increments.to_frame("temperature")
+        .assign(weekday=temperature_increments.index.get_level_values("time").dayofweek)
+        .set_index(["temperature", "weekday"], append=True)
+    )
+    aligned_increment_to_params = hourly_params.align(increment_index)[0]
+    hourly_params_at_all_locations = xr.DataArray.from_series(
+        aligned_increment_to_params.droplevel(["weekday", "temperature"])
+    )
+    # daily heat is multiplied by the hourly paramater value to get the relative heat demand for that hour
+    hourly_heat = hourly_params_at_all_locations * daily_heat
+
+    hourly_heat = hour_and_day_to_datetime(hourly_heat)
+
+    return hourly_heat
+
+
+def hour_and_day_to_datetime(da):
+    da = da.stack(new_time=["time", "hour"])
+    new_time = da.new_time.to_index()
+    da.coords["new_time"] = new_time.get_level_values(0) + pd.to_timedelta(
+        new_time.get_level_values(1), unit="H"
+    )
+    return da.rename({"new_time": "time"})
+
+
+def read_daily_parameters(input_path):
+    # Direct copy from https://github.com/oruhnau/when2heat/blob/351bd1a2f9392ed50a7bdb732a103c9327c51846/scripts/read.py
+    file = os.path.join(input_path, "daily_demand.csv")
+    return pd.read_csv(file, sep=";", decimal=",", header=[0, 1], index_col=0)
+
+
+def read_hourly_parameters(input_path):
+    # Modified from https://github.com/oruhnau/when2heat/blob/351bd1a2f9392ed50a7bdb732a103c9327c51846/scripts/read.py
+    # to set columns as integer
+    parameters = {}
+
+    def _csv_reader(building_type):
+        filename = f"hourly_factors_{building_type}.csv"
+        filepath = os.path.join(input_path, filename)
+
+        # MultiIndex for commercial heat because of weekday dependency
+        index_col = [0, 1] if building_type == "COM" else 0
+        return pd.read_csv(filepath, sep=";", decimal=",", index_col=index_col).apply(
+            pd.to_numeric, downcast="float"
+        )
+
+    parameters["COM"] = _csv_reader("COM")
+
+    for building_type in ["SFH", "MFH"]:
+        parameters[building_type] = (
+            _csv_reader(building_type)
+            .rename_axis(index="time")
+            .align(parameters["COM"])[0]
+        )
+
+    # We postprocess the dataframe from the CSV to make it easier to use in subsequent operations.
+    combined_df = pd.concat(
+        parameters.values(), keys=parameters.keys(), names=["building"]
+    )
+    combined_df.columns = combined_df.columns.astype(int).rename("temperature")
+    combined_df = combined_df.rename(lambda x: int(x.replace(":00", "")), level="time")
+    combined_df = combined_df.rename_axis(index={"time": "hour"})
+    return combined_df.stack()
+
+
+def get_reference_temperature(temperature: xr.DataArray, time_dim="time"):
+    # Modified from https://github.com/oruhnau/when2heat/blob/351bd1a2f9392ed50a7bdb732a103c9327c51846/scripts/demand.py
+    # to expect xarray not pandas
+
+    # Daily average
+    daily_average = temperature.resample(time="1D").mean(time_dim)
+
+    # Weighted mean, method for which is given in [@Ruhnau:2019]
+    return sum(
+        (0.5**i) * daily_average.shift({time_dim: i}).bfill(time_dim) for i in range(4)
+    ) / sum(0.5**i for i in range(4))
+
+
+def get_daily_heat_demand(temperature, wind, all_parameters):
+    # Direct copy from https://github.com/oruhnau/when2heat/blob/351bd1a2f9392ed50a7bdb732a103c9327c51846/scripts/demand.py
+
+    def heat_function(t, parameters):
+        # BDEW et al. 2015 describes this function combining parameters
+        celsius = t - 273.15  # The temperature input is in Kelvin
+
+        sigmoid = (
+            parameters["A"]
+            / (1 + (parameters["B"] / (celsius - 40)) ** parameters["C"])
+            + parameters["D"]
+        )
+
+        linear = xr.concat(
+            [parameters[f"m_{i}"] * celsius + parameters[f"b_{i}"] for i in ["s", "w"]],
+            dim="param",
+        ).max("param")
+
+        return sigmoid + linear
+
+    return daily(temperature, wind, all_parameters, heat_function)
+
+
+def daily(temperature, wind, all_parameters, func):
+    """
+    Modified from https://github.com/oruhnau/when2heat/blob/351bd1a2f9392ed50a7bdb732a103c9327c51846/scripts/demand.py to not prescribe index level names.
+    All locations are separated by the average wind speed with the threshold 4.4 m/s
+    separating windy and not-windy (normal) locations, then relevant paramaters for that
+    windiness are applied in a function derived from [@BDEW:2015] to get "daily heat demand".
+    """
+
+    buildings = ["SFH", "MFH", "COM"]
+
+    return xr.concat(
+        [
+            func(
+                temperature.where(wind <= 4.4), all_parameters[(building, "normal")]
+            ).fillna(
+                func(temperature.where(wind > 4.4), all_parameters[(building, "windy")])
+            )
+            for building in buildings
+        ],
+        dim=pd.Index(buildings, name="building"),
+    )
+
+
+if __name__ == "__main__":
+    get_unscaled_heat_profiles(
+        path_to_population=snakemake.input.population,
+        path_to_wind_speed=snakemake.input.wind_speed,
+        path_to_temperature=snakemake.input.temperature,
+        path_to_when2heat_params=snakemake.input.when2heat,
+        lat_name=snakemake.params.lat_name,
+        lon_name=snakemake.params.lon_name,
+        year=snakemake.wildcards.year,
+        out_path=snakemake.output[0],
+    )

--- a/scripts/heat/population_per_gridbox.py
+++ b/scripts/heat/population_per_gridbox.py
@@ -1,0 +1,100 @@
+import math
+
+import geopandas as gpd
+import pandas as pd
+import rasterio
+import xarray as xr
+from rasterstats import zonal_stats
+
+EPSG_3035 = "EPSG:3035"
+WGS84 = "EPSG:4326"
+GRIDBOX_SIZE = 25000  # MERRA-2 grid
+idx = pd.IndexSlice
+
+
+# FIXME this will most likely be entirely replaced once a more generalised way to deal
+# with spatial units is available
+def gridded_weather_population(
+    path_to_population,
+    path_to_locations,
+    path_to_wind_speed,  # FIXME: this is used to get the coordinates, but nothing else
+    lat_name,
+    lon_name,
+    out_path,
+):
+    # preprocessed weather data is gridded across Europe with WGS84 projection and
+    # includes hourly temperature (in K), average wind speed (in m/s) at every grid point.
+    wind_speed_ds = xr.open_dataset(path_to_wind_speed)
+
+    # Locations are shapefiles at the resolution of interest (e.g. countries for resolution `national`)
+    locations = gpd.read_file(path_to_locations)
+
+    gridbox_points = gpd.GeoDataFrame(
+        geometry=gpd.points_from_xy(
+            wind_speed_ds[lon_name].values, wind_speed_ds[lat_name].values
+        ),
+        index=wind_speed_ds.site.to_index(),
+        crs=WGS84,
+    )
+    # To go from a grid of points to a grid of boxes filling the entire space,
+    # we `buffer` to create a grid of circles whose edges just touch,
+    # then we define the envelope of that circle to create a square.
+    gridbox_points = gridbox_points.to_crs(EPSG_3035)
+    gridbox = gpd.GeoDataFrame(
+        gridbox_points.index.to_frame(),
+        geometry=gridbox_points.buffer(GRIDBOX_SIZE).envelope,
+    )
+    # `Overlay` creates new shapes that are either complete gridboxes or partial ones that
+    # sit inside a specific location.
+    gridboxes_mapped_to_locations = gpd.overlay(
+        gridbox.to_crs(WGS84), locations.to_crs(WGS84)
+    )
+
+    with rasterio.open(path_to_population) as src:
+        array = src.read(1)
+        meta = src.meta
+        affine = src.transform
+
+        population_per_complete_or_partial_gridbox_polygon = zonal_stats(
+            gridboxes_mapped_to_locations.to_crs(meta["crs"]),
+            array,
+            affine=affine,
+            stats="sum",
+            nodata=meta["nodata"],
+        )
+        gridboxes_mapped_to_locations["population"] = [
+            i["sum"] for i in population_per_complete_or_partial_gridbox_polygon
+        ]
+
+        population_per_country = zonal_stats(
+            locations.to_crs(meta["crs"]),
+            array,
+            affine=affine,
+            stats="sum",
+            nodata=meta["nodata"],
+        )
+        locations["population"] = [i["sum"] for i in population_per_country]
+
+    # Confirm that the total population is valid (i.e. we haven't picked up or lost regions).
+    # This is a test that the gridboxes cover all land with population that we are interested in.
+    assert math.isclose(
+        locations.population.sum(),
+        gridboxes_mapped_to_locations.population.sum(),
+        abs_tol=10**3,
+    )
+
+    population_da = xr.DataArray.from_series(
+        gridboxes_mapped_to_locations.set_index("site").population
+    )
+    population_da.to_netcdf(out_path)
+
+
+if __name__ == "__main__":
+    gridded_weather_population(
+        path_to_population=snakemake.input.population,
+        path_to_locations=snakemake.input.locations,
+        path_to_wind_speed=snakemake.input.wind_speed,
+        lat_name=snakemake.params.lat_name,
+        lon_name=snakemake.params.lon_name,
+        out_path=snakemake.output[0],
+    )

--- a/scripts/heat/population_per_gridbox.py
+++ b/scripts/heat/population_per_gridbox.py
@@ -84,7 +84,7 @@ def gridded_weather_population(
     )
 
     population_da = xr.DataArray.from_series(
-        gridboxes_mapped_to_locations.set_index("site").population
+        gridboxes_mapped_to_locations.set_index(["site", "id"]).population
     )
     population_da.to_netcdf(out_path)
 


### PR DESCRIPTION
Fixes #341.

Partially solves #299.

Implements gridded heat demand timeseries as an intermediate step towards completing #16. Based on a blend of sector-coupled-euro-calliope and balancing-act. So far, it is not connected to the main DAG, but you can build a gridded heat demand profile by running, for example:

```
snakemake --cores 1 --configfile config/minimal.yaml -f build/data/national/gridded_hourly_unscaled_heat_demand_2016.nc
```

Next step will be to wire this up with the existing heat code to generate scaled, per-zone heat demand profiles.

## Checklist

Any checks which are not relevant to the PR can be pre-checked by the PR creator. All others should be checked by the reviewer. You can add extra checklist items here if required by the PR.

- [ ] CHANGELOG updated
- [ ] Minimal workflow tests pass
- [x] Tests added to cover contribution
- [x] Documentation updated
- [x] Configuration schema updated
