### PR TITLE
Pin hdf5 and h5py in all xarray environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 * **FIX** fixed optimisation tolerance of hydro power plants from xtol to xatol (#266).
 * **FIX** source of Exclusive Economic Zones (EEZ) to use a cache on [zenodo](https://sandbox.zenodo.org/records/45135) so that we can keep using v11 (#332).  FIXME: update to actual zenodo record before next Euro-Calliope release.
 * **FIX** fixed rule `download_basins_database`, which previously failed on some linux and mac machines, by requiring a more recent curl in the environment `envs/shell.yaml` (#267).
+* **FIX** pin `h5py` and `hdf5` in all environments which rely on `xarray`, to prevent issues on linux-x86.
 
 ## 1.1.0 (2021-12-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@
 * **FIX** fixed optimisation tolerance of hydro power plants from xtol to xatol (#266).
 * **FIX** source of Exclusive Economic Zones (EEZ) to use a cache on [zenodo](https://sandbox.zenodo.org/records/45135) so that we can keep using v11 (#332).  FIXME: update to actual zenodo record before next Euro-Calliope release.
 * **FIX** fixed rule `download_basins_database`, which previously failed on some linux and mac machines, by requiring a more recent curl in the environment `envs/shell.yaml` (#267).
-* **FIX** pin `h5py`, `hdf5` and `libnetcdf` in all environments which rely on `xarray`, to prevent issues on linux-x86.
+* **FIX** pin `h5py`, `hdf5` and `libnetcdf` in all environments which rely on `xarray`, to prevent issues on linux-x86 (#357).
 
 ## 1.1.0 (2021-12-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@
 * **FIX** fixed optimisation tolerance of hydro power plants from xtol to xatol (#266).
 * **FIX** source of Exclusive Economic Zones (EEZ) to use a cache on [zenodo](https://sandbox.zenodo.org/records/45135) so that we can keep using v11 (#332).  FIXME: update to actual zenodo record before next Euro-Calliope release.
 * **FIX** fixed rule `download_basins_database`, which previously failed on some linux and mac machines, by requiring a more recent curl in the environment `envs/shell.yaml` (#267).
-* **FIX** pin `h5py` and `hdf5` in all environments which rely on `xarray`, to prevent issues on linux-x86.
+* **FIX** pin `h5py`, `hdf5` and `libnetcdf` in all environments which rely on `xarray`, to prevent issues on linux-x86.
 
 ## 1.1.0 (2021-12-22)
 

--- a/envs/default.yaml
+++ b/envs/default.yaml
@@ -16,6 +16,7 @@ dependencies:
     - netCDF4=1.5.6
     - hdf5=1.10
     - h5py=3.1.0
+    - libnetcdf=4.7
     - pip:
         - -e ./lib
         - styleframe==4.2

--- a/envs/default.yaml
+++ b/envs/default.yaml
@@ -14,6 +14,8 @@ dependencies:
     - pip=21.0.1
     - xarray=0.17.0
     - netCDF4=1.5.6
+    - hdf5=1.10
+    - h5py=3.1.0
     - pip:
         - -e ./lib
         - styleframe==4.2

--- a/envs/geo.yaml
+++ b/envs/geo.yaml
@@ -20,5 +20,7 @@ dependencies:
     - networkx=2.5
     - pycountry=18.12.8
     - pip=21.0.1
+    - hdf5=1.10
+    - h5py=3.1.0
     - pip:
         - -e ./lib[geo]

--- a/envs/geo.yaml
+++ b/envs/geo.yaml
@@ -22,5 +22,6 @@ dependencies:
     - pip=21.0.1
     - hdf5=1.10
     - h5py=3.1.0
+    - libnetcdf=4.7
     - pip:
         - -e ./lib[geo]

--- a/envs/hydro.yaml
+++ b/envs/hydro.yaml
@@ -18,5 +18,7 @@ dependencies:
     - pycountry=18.12.8
     - atlite=0.2.1
     - pip=21.0.1
+    - hdf5=1.10
+    - h5py=3.1.0
     - pip:
         - -e ./lib[geo]

--- a/envs/hydro.yaml
+++ b/envs/hydro.yaml
@@ -20,5 +20,6 @@ dependencies:
     - pip=21.0.1
     - hdf5=1.10
     - h5py=3.1.0
+    - libnetcdf=4.7
     - pip:
         - -e ./lib[geo]

--- a/envs/test.yaml
+++ b/envs/test.yaml
@@ -13,3 +13,5 @@ dependencies:
     - pytest-html=3.2.0
     - calliope=0.6.10
     - pyomo=6.4.1
+    - hdf5=1.10
+    - h5py=3.1.0

--- a/envs/test.yaml
+++ b/envs/test.yaml
@@ -15,3 +15,4 @@ dependencies:
     - pyomo=6.4.1
     - hdf5=1.10
     - h5py=3.1.0
+    - libnetcdf=4.7


### PR DESCRIPTION
This is pulling out the fix from #317 (commit 7b6bcf3) to resolve errors importing xarray on linux-x86, given that it seems #317 might not be merged any time soon.

## Checklist

Any checks which are not relevant to the PR can be pre-checked by the PR creator. All others should be checked by the reviewer. You can add extra checklist items here if required by the PR.

- [x] CHANGELOG updated
- [ ] Minimal workflow tests pass
- [x] Tests added to cover contribution
- [x] Documentation updated
- [x] Configuration schema updated
