### PR TITLE
Fix the import of the new industry module

### DIFF
--- a/.github/workflows/schemavalidation.yaml
+++ b/.github/workflows/schemavalidation.yaml
@@ -33,4 +33,4 @@ jobs:
               run: python ./tests/validate_schema.py ./tests/resources/schema.yaml
             # Modules
             - name: Validate industry config
-              run: python ./tests/validate_schema.py ./modules/industry/schema.yaml --config ./modules/industry/config.yaml
+              run: python ./tests/validate_schema.py ./modules/industry/schema.yaml --config ./modules/industry/config.yaml --level industry

--- a/Snakefile
+++ b/Snakefile
@@ -6,18 +6,6 @@ from snakemake.utils import validate, min_version, makedirs
 configfile: "config/default.yaml"
 validate(config, "config/schema.yaml")
 
-# >>>>>> Include modules >>>>>>
-# Industry
-configfile: "modules/industry/config.yaml"
-validate(config, "modules/industry/schema.yaml")
-
-module module_industry:
-    snakefile: "modules/industry/industry.smk"
-    config: config["industry"]
-use rule * from module_industry as module_industry_*
-# <<<<<< Include modules <<<<<<
-
-
 root_dir = config["root-directory"] + "/" if config["root-directory"] not in ["", "."] else ""
 __version__ = open(f"{root_dir}VERSION").readlines()[0].strip()
 test_dir = f"{root_dir}tests/"
@@ -38,6 +26,7 @@ include: "./rules/nuclear.smk"
 include: "./rules/transport.smk"
 include: "./rules/sync.smk"
 include: "./rules/heat.smk"
+include: "./rules/modules.smk"
 min_version("8.10")
 localrules: all, clean
 wildcard_constraints:
@@ -83,6 +72,7 @@ onerror:
 rule all:
     message: "Generate euro-calliope pre-built models and run tests."
     localrule: True
+    default_target: True
     input:
         "build/logs/continental/test.success",
         "build/logs/national/test.success",

--- a/modules/industry/industry.smk
+++ b/modules/industry/industry.smk
@@ -1,3 +1,5 @@
+from snakemake.utils import validate
+
 # Paths dependent on main Snakefile
 MODULE_PATH = "modules/industry"
 BUILD_PATH = f"{MODULE_PATH}/build"
@@ -6,6 +8,8 @@ DATA_PATH = f"{MODULE_PATH}/raw_data"
 # Paths relative to this snakefile (snakemake behaviour is inconsitent)
 SCRIPT_PATH = "scripts"  # scripts are called relative to this file
 CONDA_PATH = "./env_industry.yaml"
+
+validate(config, "./schema.yaml")
 
 # Ensure rules are defined in order.
 # Otherwise commands like "rules.rulename.output" won't work!

--- a/modules/industry/schema.yaml
+++ b/modules/industry/schema.yaml
@@ -1,55 +1,50 @@
 $schema: https://json-schema.org/draft/2020-12/schema
 type: object
-additionalProperties: true
+additionalProperties: false
 properties:
-    industry:
-        description: Module subsection to ensure no name conflicts are possible between modules.
+    inputs:
         type: object
         additionalProperties: false
+        description: Inputs are paths of prerequired files.
         properties:
-            inputs:
+            path-energy-balances:
+                type: string
+                description: |
+                    Annual energy balance file.
+                    Columns [cat_code,carrier_code,unit,country,year,value].
+            path-cat-names:
+                type: string
+                description: |
+                    Category mapping file.
+                    Columns [cat_code,top_cat,sub_cat_contribution,sub_cat_1,sub_cat_2,jrc_idees].
+            path-carrier-names:
+                type: string
+                description: |
+                    Carrier mapping file.
+                    Columns [carrier_code,carrier_name,hh_carrier_name,com_carrier_name,ind_carrier_name,oth_carrier_name].
+            path-jrc-industry-energy:
+                type: string
+                description: |
+                    JRC processed industry energy demand .nc file.
+            path-jrc-industry-production:
+                type: string
+                description: |
+                    JRC processed industrial production .nc file.
+    outputs:
+        type: object
+        description: Outputs are paths for the files produced by the module.
+    params:
+        type: object
+        additionalProperties: false
+        description: Parameters allow users to configure module behaviour.
+        properties:
+            steel:
                 type: object
                 additionalProperties: false
-                description: Inputs are paths of prerequired files.
+                description: "Parameters specific to the 'Iron and steel' industry category."
                 properties:
-                    path-energy-balances:
-                        type: string
-                        description: |
-                            Annual energy balance file.
-                            Columns [cat_code,carrier_code,unit,country,year,value].
-                    path-cat-names:
-                        type: string
-                        description: |
-                            Category mapping file.
-                            Columns [cat_code,top_cat,sub_cat_contribution,sub_cat_1,sub_cat_2,jrc_idees].
-                    path-carrier-names:
-                        type: string
-                        description: |
-                            Carrier mapping file.
-                            Columns [carrier_code,carrier_name,hh_carrier_name,com_carrier_name,ind_carrier_name,oth_carrier_name].
-                    path-jrc-industry-energy:
-                        type: string
-                        description: |
-                            JRC processed industry energy demand .nc file.
-                    path-jrc-industry-production:
-                        type: string
-                        description: |
-                            JRC processed industrial production .nc file.
-            outputs:
-                type: object
-                description: Outputs are paths for the files produced by the module.
-            params:
-                type: object
-                additionalProperties: false
-                description: Parameters allow users to configure module behaviour.
-                properties:
-                    steel:
-                        type: object
-                        additionalProperties: false
-                        description: "Parameters specific to the 'Iron and steel' industry category."
-                        properties:
-                            recycled-steel-share:
-                                type: number
-                                description: "Share of recycled metal in the H-DRI steel process."
-                                minimum: 0
-                                maximum: 1
+                    recycled-steel-share:
+                        type: number
+                        description: "Share of recycled metal in the H-DRI steel process."
+                        minimum: 0
+                        maximum: 1

--- a/rules/modules.smk
+++ b/rules/modules.smk
@@ -1,0 +1,9 @@
+# Industry
+configfile: "./modules/industry/config.yaml"
+validate(config["industry"], "../modules/industry/schema.yaml")
+
+
+module module_industry:
+    snakefile: "../modules/industry/industry.smk"
+    config: config["industry"]
+use rule * from module_industry as module_industry_*

--- a/rules/modules.smk
+++ b/rules/modules.smk
@@ -1,8 +1,5 @@
 # Industry
 configfile: "./modules/industry/config.yaml"
-validate(config["industry"], "../modules/industry/schema.yaml")
-
-
 module module_industry:
     snakefile: "../modules/industry/industry.smk"
     config: config["industry"]

--- a/tests/validate_schema.py
+++ b/tests/validate_schema.py
@@ -12,6 +12,13 @@ parser.add_argument(
         "If not given, schema itself will be validated against JSON schema Draft 2020-12"
     ),
 )
+parser.add_argument(
+    "--level",
+    help=(
+        "level of the configuration to validate. "
+        "If not given, this will validate the entire configuration."
+    ),
+)
 args = parser.parse_args()
 
 with open(args.schema) as f:
@@ -20,6 +27,8 @@ with open(args.schema) as f:
 if args.config:
     with open(args.config) as f:
         config = yaml.safe_load(f)
+    if args.level:
+        config = config[args.level]
     jsonschema.validate(config, schema)
 else:
     jsonschema.Draft202012Validator.check_schema(schema)


### PR DESCRIPTION
There were two problems with the industry module that broke the main workflow:

* `all` rule was overwritten
* `config` was overwritten

These are fixed here.


## Checklist

Any checks which are not relevant to the PR can be pre-checked by the PR creator. All others should be checked by the reviewer. You can add extra checklist items here if required by the PR.

- [ ] CHANGELOG updated
- [ ] Minimal workflow tests pass
- [ ] Tests added to cover contribution
- [ ] Documentation updated
- [ ] Configuration schema updated
