### PR TITLE
Update sorting method in ehighways renaming

### DIFF
--- a/scripts/shapes/units.py
+++ b/scripts/shapes/units.py
@@ -45,14 +45,12 @@ def _build_layer(
         resolution_config
     """
     crs = [layer.crs for layer in source_layers.values()][0]
-    layer = pd.concat(
-        [
-            source_layers[source_layer][
-                source_layers[source_layer].country_code == _iso3(country)
-            ]
-            for country, source_layer in resolution_config.items()
+    layer = pd.concat([
+        source_layers[source_layer][
+            source_layers[source_layer].country_code == _iso3(country)
         ]
-    )
+        for country, source_layer in resolution_config.items()
+    ])
     assert isinstance(layer, pd.DataFrame)
     return gpd.GeoDataFrame(layer, crs=crs).reset_index(drop=True)
 
@@ -85,17 +83,15 @@ def _validate_resolution_config(
 ):
     missing_countries = set(all_countries).difference(resolution_config)
 
-    assert (
-        not missing_countries
-    ), f"Missing countries in {resolution} resolution configuration: {missing_countries}"
+    assert not missing_countries, f"Missing countries in {resolution} resolution configuration: {missing_countries}"
 
 
 def _verify_all_countries_captured(
     countries: list[str], units: gpd.GeoDataFrame, resolution: str
 ):
-    missing_countries = set(units.country_code).difference(
-        [_iso3(country) for country in countries]
-    )
+    missing_countries = set(units.country_code).difference([
+        _iso3(country) for country in countries
+    ])
     assert (
         not missing_countries
     ), f"Countries are missing in {resolution} resolution shapes: {missing_countries}"


### PR DESCRIPTION
Fixes #397.

The initial method was string sorting so that [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11] would be sorted as [1, 10, 11, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11].

This will now sort the abovementioned example correctly, but also handle ordering of `1-1.1`, `1-2.1` etc. by extracting all digits from the string and then combining them together into a new number (111, 121 in this example).

## Checklist

Any checks which are not relevant to the PR can be pre-checked by the PR creator. All others should be checked by the reviewer. You can add extra checklist items here if required by the PR.

- [x] CHANGELOG updated
- [x] Minimal workflow tests pass
- [x] Tests added to cover contribution
- [x] Documentation updated
- [x] Configuration schema updated
