### PR TITLE
Fix warning spam caused by geopandas update

### DIFF
--- a/rules/hydro.smk
+++ b/rules/hydro.smk
@@ -155,7 +155,7 @@ rule hydro_capacities:
 rule capacity_factors_hydro:
     message: "Generate capacityfactor time series for hydro electricity on {wildcards.resolution} resolution."
     input:
-        capacities = rules.hydro_capacities.output[0],
+        capacities = rules.hydro_capacities.output.supply,
         stations = "build/data/hydro-electricity-with-energy-inflow-{first_year}-{final_year}.nc".format(
             first_year = config["scope"]["temporal"]["first-year"],
             final_year = config["scope"]["temporal"]["final-year"]

--- a/scripts/hydro/capacityfactors_hydro.py
+++ b/scripts/hydro/capacityfactors_hydro.py
@@ -38,7 +38,7 @@ def time_series(plants, locations, capacities):
         index=plants.id,
     )
     location_of_plant = gpd.sjoin(
-        plant_centroids, locations, how="left", op="intersects"
+        plant_centroids, locations, how="left", predicate="intersects"
     )["index_right"]
     location_of_plant = location_of_plant[
         ~location_of_plant.index.duplicated()

--- a/scripts/hydro/hydro_capacities.py
+++ b/scripts/hydro/hydro_capacities.py
@@ -36,7 +36,7 @@ def capacities_per_location(plants, locations, tech_name):
         index=plants.index,
     )
     location_of_plant = gpd.sjoin(
-        plant_centroids, locations, how="left", op="intersects"
+        plant_centroids, locations, how="left", predicate="intersects"
     )["index_right"]
     location_of_plant = location_of_plant[~location_of_plant.index.duplicated()]
     return (

--- a/scripts/wind-and-solar/shared_coast.py
+++ b/scripts/wind-and-solar/shared_coast.py
@@ -116,7 +116,7 @@ def _get_coastal_units_as_linestrings(
     # slightly overlap the continent polygon boundary.
     temp_units = units.copy()
     temp_units["geometry"] = units.geometry.buffer(units.total_bounds.mean() * 1e-6)
-    non_coastal_units = gpd.sjoin(temp_units, merged_units, op="within")
+    non_coastal_units = gpd.sjoin(temp_units, merged_units, predicate="within")
     coastal_units = units.loc[~units.id.isin(non_coastal_units.id_left)].set_index("id")
 
     # Simplify geometries to get rid of tiny islands that slow down the computation and


### PR DESCRIPTION
Fixes  spam caused by geopandas (`op` was replaced with  `predicate`). Found while debugging something else.

See: https://geopandas.org/en/stable/docs/reference/api/geopandas.sjoin.html

## Checklist

Any checks which are not relevant to the PR can be pre-checked by the PR creator. All others should be checked by the reviewer. You can add extra checklist items here if required by the PR.

- [ ] ~~CHANGELOG updated~~
- [x] Minimal workflow tests pass
- [ ] ~~Tests added to cover contribution~~
- [ ] ~~Documentation updated~~
- [ ] ~~Configuration schema updated~~
