### PR TITLE
Update zenodo link to v1.1 of pre-built model

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,9 +3,11 @@
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
 version: 2
-
+build:
+  os: ubuntu-22.04 # required
+  tools:
+    python: mambaforge-4.10
 mkdocs:
   configuration: mkdocs.yaml
-
 conda:
   environment: envs/docs.yaml

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 Models of the European electricity system for _Calliope_.
 
-This repository contains the workflow routines that automatically build models from raw data. Alternatively to building models yourself, you can use [pre-built models](https://doi.org/10.5281/zenodo.3949553) that run out-of-the-box. You can find a more detailed description of the first application in a [scientific article in Joule](https://doi.org/10.1016/j.joule.2020.07.018).
+This repository contains the workflow routines that automatically build models from raw data. Alternatively to building models yourself, you can use [pre-built models](https://doi.org/10.5281/zenodo.5803058) that run out-of-the-box. You can find a more detailed description of the first application in a [scientific article in Joule](https://doi.org/10.1016/j.joule.2020.07.018).
 
 [![article DOI](https://img.shields.io/badge/article-10.1016/j.joule.2020.07.018-blue)](https://doi.org/10.1016/j.joule.2020.07.018)
-[![pre-built models DOI](https://img.shields.io/badge/prebuilts-10.5281%2Fzenodo.3949553-blue)](https://doi.org/10.5281/zenodo.3949553)
+[![pre-built models DOI](https://img.shields.io/badge/prebuilts-10.5281%2Fzenodo.5803058-blue)](https://doi.org/10.5281/zenodo.5803058).
 [![Documentation Status](https://readthedocs.org/projects/euro-calliope/badge/?version=latest)](https://euro-calliope.readthedocs.io/en/latest/?badge=latest)
 [![Check Markdown links](https://github.com/calliope-project/euro-calliope/actions/workflows/externallinks.yaml/badge.svg)](https://github.com/calliope-project/euro-calliope/actions/workflows/externallinks.yaml)
 [![Tests of YAML configuration and schema](https://github.com/calliope-project/euro-calliope/actions/workflows/schemavalidation.yaml/badge.svg)](https://github.com/calliope-project/euro-calliope/actions/workflows/schemavalidation.yaml)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 # Euro-Calliope
 
 [![article DOI](https://img.shields.io/badge/article-10.1016/j.joule.2020.07.018-blue)](https://doi.org/10.1016/j.joule.2020.07.018)
-[![pre-built models DOI](https://img.shields.io/badge/prebuilts-10.5281%2Fzenodo.3949553-blue)](https://doi.org/10.5281/zenodo.3949553)
+[![pre-built models DOI](https://img.shields.io/badge/prebuilts-10.5281%2Fzenodo.5803058-blue)](https://doi.org/10.5281/zenodo.5803058).
 [![workflow DOI](https://img.shields.io/badge/workflow-10.5281/zenodo.3949793-blue)](https://doi.org/10.5281/zenodo.3949793)
 
 Models of the European electricity system for _Calliope_.

--- a/docs/model/pre-built.md
+++ b/docs/model/pre-built.md
@@ -7,7 +7,7 @@ After going through these first steps, we advise you to head over to [Calliope's
 
 ## Prepare
 
-1. Download the pre-built models: [![pre-built models DOI](https://img.shields.io/badge/prebuilts-10.5281%2Fzenodo.3949553-blue)](https://doi.org/10.5281/zenodo.3949553).
+1. Download the pre-built models: [![pre-built models DOI](https://img.shields.io/badge/prebuilts-10.5281%2Fzenodo.5803058-blue)](https://doi.org/10.5281/zenodo.5803058).
 
 2. Install a Gurobi license on your computer ([academic license](https://www.gurobi.com/downloads/end-user-license-agreement-academic/) comes at no cost), or [choose a different solver](./customisation.md#manual).
 


### PR DESCRIPTION
Fixes version of pre-built Euro-Calliope being referenced in the docs/README. Currently users are directed to v1.0 and have to notice the Zenodo banner RE a newer version being available.

This is a patch on main and we should probably then move the v1.1 tag to this commit so that the stable version of the docs updates accordingly.

## Checklist

Any checks which are not relevant to the PR can be pre-checked by the PR creator. All others should be checked by the reviewer. You can add extra checklist items here if required by the PR.

- [ ] CHANGELOG updated
- [ ] Minimal workflow tests pass
- [ ] Tests added to cover contribution
- [ ] Documentation updated
- [ ] Configuration schema updated
